### PR TITLE
don't use generic typing in TraitType

### DIFF
--- a/lonboard/traits.py
+++ b/lonboard/traits.py
@@ -21,7 +21,7 @@ from lonboard.serialization import (
 )
 
 
-class PyarrowTableTrait(traitlets.TraitType[pa.Table, pa.Table]):
+class PyarrowTableTrait(traitlets.TraitType):
     """A traitlets trait for a geospatial pyarrow table"""
 
     default_value = None


### PR DESCRIPTION
This was just added in a very recent traitlets version, and so isn't available e.g. with the default binder traitlets version