### PR TITLE
wip sync view state between python and JS

### DIFF
--- a/lonboard/layer.py
+++ b/lonboard/layer.py
@@ -233,6 +233,7 @@ class PathLayer(BaseLayer):
     _esm = bundler_output_dir / "path-layer.js"
     _layer_type = traitlets.Unicode("path").tag(sync=True)
     _initial_view_state = traitlets.Dict().tag(sync=True)
+    _view_state = traitlets.Any(allow_none=True).tag(sync=True)
 
     # Number of rows per chunk for serializing table and accessor columns
     _rows_per_chunk = traitlets.Int()
@@ -338,7 +339,7 @@ class PathLayer(BaseLayer):
         table = geopandas_to_geoarrow(gdf)
         return cls(table=table, **kwargs)
 
-    @traitlets.default("_initial_view_state")
+    @traitlets.default("_view_state")
     def _default_initial_view_state(self):
         return compute_view(self.table)
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,0 +1,51 @@
+import * as React from "react";
+import { useModel } from "@anywidget/react";
+import { debounce } from "./util";
+
+const debouncedModelSaveViewState = debounce((model) => {
+  console.log("DEBOUNCED");
+  const viewState = model.get("_view_state");
+
+  // transitionInterpolator is sometimes a key in the view state while panning
+  // This is a function object and so can't be serialized via JSON.
+  //
+  // In the future anywidget may support custom serializers for sending data
+  // back from JS to Python. Until then, we need to clean the object ourselves.
+  // Because this is in a debounce it shouldn't often mess with deck's internal
+  // transition state it expects, because hopefully the transition will have
+  // finished in the 300ms that the user has stopped panning.
+  if ("transitionInterpolator" in viewState) {
+    console.debug("Deleting transitionInterpolator!");
+    delete viewState.transitionInterpolator;
+    model.set("_view_state", viewState);
+  }
+
+  model.save_changes();
+}, 300);
+
+export function useModelStateDebounced<T>(
+  key: string,
+  wait: number
+): [T, (value: T) => void] {
+  let model = useModel();
+  let [value, setValue] = React.useState(model.get(key));
+  React.useEffect(() => {
+    let callback = () => {
+      console.log("callback");
+      console.log(model.get(key));
+      setValue(model.get(key));
+    };
+    model.on(`change:${key}`, callback);
+    console.log(`model on change view state`);
+    return () => model.off(`change:${key}`, callback);
+  }, [model, key]);
+  return [
+    value,
+    (value) => {
+      model.set(key, value);
+      // Note: I think this has to be defined outside of this function so that
+      // you're calling debounce on the same function object?
+      debouncedModelSaveViewState(model);
+    },
+  ];
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,10 @@
+// From https://www.joshwcomeau.com/snippets/javascript/debounce/
+export const debounce = (callback: (args) => void, wait: number) => {
+  let timeoutId = null;
+  return (...args) => {
+    window.clearTimeout(timeoutId);
+    timeoutId = window.setTimeout(() => {
+      callback.apply(null, args);
+    }, wait);
+  };
+};


### PR DESCRIPTION
Closes https://github.com/developmentseed/lonboard/issues/112

This is working for one way sync from JS to python, but when I set a new object on the python side, it isn't automatically synced to JS for some reason. I have to manually call `widget.send_state()` for it to be sent to JS