### PR TITLE
bump deck.gl-layers and parquet-wasm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@geoarrow/deck.gl-layers": "^0.1.0",
         "apache-arrow": "^13.0.0",
         "maplibre-gl": "^3.5.0",
-        "parquet-wasm": "0.5.0-alpha.1",
+        "parquet-wasm": "0.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-map-gl": "^7.1.5"
@@ -1640,9 +1640,9 @@
       }
     },
     "node_modules/parquet-wasm": {
-      "version": "0.5.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/parquet-wasm/-/parquet-wasm-0.5.0-alpha.1.tgz",
-      "integrity": "sha512-qLvpCqpARGCrLpLkBWw7uVCWn05HJ6pxpjQfv6SS+FT/hOfGQloHhcv/1akFBTECpK0kK6udRCtVb8MMTjzGtg=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/parquet-wasm/-/parquet-wasm-0.5.0.tgz",
+      "integrity": "sha512-XN3EW+3xf915QgpxCvfCdVYsxDLXz+BckKLDlMo41cbipSYD8x+F/3lGcrWtxdY6uJgAmtb+SX3tS+9PPsplQA=="
     },
     "node_modules/pbf": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@geoarrow/deck.gl-layers": "^0.1.0",
     "apache-arrow": "^13.0.0",
     "maplibre-gl": "^3.5.0",
-    "parquet-wasm": "0.5.0-alpha.1",
+    "parquet-wasm": "0.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-map-gl": "^7.1.5"

--- a/src/parquet.ts
+++ b/src/parquet.ts
@@ -4,7 +4,7 @@ import * as arrow from "apache-arrow";
 
 // NOTE: this version must be synced exactly with the parquet-wasm version in
 // use.
-const PARQUET_WASM_VERSION = "0.5.0-alpha.1";
+const PARQUET_WASM_VERSION = "0.5.0";
 const PARQUET_WASM_CDN_URL = `https://cdn.jsdelivr.net/npm/parquet-wasm@${PARQUET_WASM_VERSION}/esm/arrow2_bg.wasm`;
 let WASM_READY: boolean = false;
 


### PR DESCRIPTION
Note: this is blocked on me having fast enough internet (not on a train) to publish parquet-wasm 0.5 and test this.

Closes https://github.com/developmentseed/lonboard/issues/91, Closes https://github.com/developmentseed/lonboard/issues/68
