### PR TITLE
Allow hex string color input to ColorAccessor

### DIFF
--- a/lonboard/traits.py
+++ b/lonboard/traits.py
@@ -70,6 +70,8 @@ class ColorAccessor(traitlets.TraitType):
 
     - A `list` or `tuple` with three or four integers, ranging between 0 and 255
       (inclusive). This will be used as the color for all objects.
+    - A `str` representing a hex color or "well known" color interpretable by
+      [matplotlib.colors.to_rgba][matplotlib.colors.to_rgba].
     - A numpy `ndarray` with two dimensions and data type [`np.uint8`][numpy.uint8]. The
       size of the second dimension must be `3` or `4`, and will correspond to either RGB
       or RGBA colors.

--- a/lonboard/traits.py
+++ b/lonboard/traits.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from typing import Any, List, Set, Tuple, Union
 
+import matplotlib as mpl
 import numpy as np
 import pyarrow as pa
 import traitlets
@@ -161,6 +162,22 @@ class ColorAccessor(traitlets.TraitType):
                 )
 
             return value
+
+        if isinstance(value, str):
+            try:
+                c = mpl.colors.to_rgba(value)  # type: ignore
+            except ValueError:
+                self.error(
+                    obj,
+                    value,
+                    info=(
+                        "Color string must be a hex string interpretable by "
+                        "matplotlib.colors.to_rgba."
+                    ),
+                )
+                return
+
+            return tuple(map(int, (np.array(c) * 255).astype(np.uint8)))
 
         self.error(obj, value)
         assert False

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -89,6 +89,27 @@ def test_color_accessor_validation_pyarrow_array_type():
         ColorAccessorWidget(color=pa.FixedSizeListArray.from_arrays(np_arr, 4))
 
 
+def test_color_accessor_validation_string():
+    # Shortened RGB
+    ColorAccessorWidget(color="#fff")
+
+    # Shortened RGBA
+    ColorAccessorWidget(color="#fff0")
+
+    # Full RGB
+    ColorAccessorWidget(color="#ffffff")
+
+    c = ColorAccessorWidget(color="#ffffffa0")
+    assert c.color[3] == 0xA0, "Expected alpha to be parsed correctly"
+
+    # HTML Aliases
+    ColorAccessorWidget(color="red")
+    ColorAccessorWidget(color="blue")
+
+    with pytest.raises(TraitError):
+        ColorAccessorWidget(color="#ff")
+
+
 class FloatAccessorWidget(Widget):
     _rows_per_chunk = 2
 


### PR DESCRIPTION
### Change list

- Allow passing a hex string like `#fff`
- Add tests

For #7 