### PR TITLE
Don't publish docs on every PR

### DIFF
--- a/.github/workflows/deploy-mkdocs.yml
+++ b/.github/workflows/deploy-mkdocs.yml
@@ -1,9 +1,11 @@
 name: Publish docs via GitHub Pages
 
+# Only run on new tags starting with `v`
 on:
   push:
-    branches:
-      - main
+    tags:
+      - 'v*'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Otherwise, the docs will reflect _main_ rather than the latest release