### PR TITLE
Deduplicate layer props

### DIFF
--- a/docs/api/layers/path-layer.md
+++ b/docs/api/layers/path-layer.md
@@ -9,3 +9,4 @@ The `PathLayer` renders lists of coordinate points as extruded polylines with mi
 ::: lonboard.PathLayer
     options:
       show_bases: false
+      inherited_members: true

--- a/docs/api/layers/scatterplot-layer.md
+++ b/docs/api/layers/scatterplot-layer.md
@@ -9,3 +9,4 @@ The `ScatterplotLayer` renders circles at given coordinates.
 ::: lonboard.ScatterplotLayer
     options:
       show_bases: false
+      inherited_members: true

--- a/docs/api/layers/solid-polygon-layer.md
+++ b/docs/api/layers/solid-polygon-layer.md
@@ -17,3 +17,4 @@ layer = SolidPolygonLayer.from_geopandas(
 ::: lonboard.SolidPolygonLayer
     options:
       show_bases: false
+      inherited_members: true

--- a/lonboard/_layer.py
+++ b/lonboard/_layer.py
@@ -30,7 +30,8 @@ class BaseLayer(Widget):
     Whether the layer responds to mouse pointer picking events.
 
     This must be set to `True` for tooltips and other interactive elements to be
-    available.
+    available. This can also be used to only allow picking on specific layers within a
+    map instance.
 
     Note that picking has some performance overhead in rendering. To get the absolute
     best rendering performance with large data (at the cost of removing interactivity),

--- a/lonboard/_layer.py
+++ b/lonboard/_layer.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import sys
 import warnings
+from typing import TYPE_CHECKING
 
 import geopandas as gpd
 import pyarrow as pa
@@ -13,9 +15,57 @@ from lonboard._serialization import infer_rows_per_chunk
 from lonboard._viewport import compute_view
 from lonboard.traits import ColorAccessor, FloatAccessor, PyarrowTableTrait
 
+if TYPE_CHECKING:
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
+
 
 class BaseLayer(Widget):
-    pass
+    table: traitlets.TraitType
+
+    pickable = traitlets.Bool(True).tag(sync=True)
+    """
+    Whether the layer responds to mouse pointer picking events.
+
+    This must be set to `True` for tooltips and other interactive elements to be
+    available.
+
+    Note that picking has some performance overhead in rendering. To get the absolute
+    best rendering performance with large data (at the cost of removing interactivity),
+    set this to `False`.
+
+    - Type: `bool`
+    - Default: `True`
+    """
+
+    _rows_per_chunk = traitlets.Int()
+    """Number of rows per chunk for serializing table and accessor columns."""
+
+    @traitlets.default("_rows_per_chunk")
+    def _default_rows_per_chunk(self):
+        return infer_rows_per_chunk(self.table)
+
+    @classmethod
+    def from_geopandas(cls, gdf: gpd.GeoDataFrame, **kwargs) -> Self:
+        """Construct a Layer from a geopandas GeoDataFrame.
+
+        The GeoDataFrame will be reprojected to EPSG:4326 if it is not already in that
+        coordinate system.
+
+        Args:
+            gdf: The GeoDataFrame to set on the layer.
+
+        Returns:
+            A Layer with the initialized data.
+        """
+        if gdf.crs and gdf.crs not in [EPSG_4326, OGC_84]:
+            warnings.warn("GeoDataFrame being reprojected to EPSG:4326")
+            gdf = gdf.to_crs(OGC_84)  # type: ignore
+
+        table = geopandas_to_geoarrow(gdf)
+        return cls(table=table, **kwargs)
 
 
 class ScatterplotLayer(BaseLayer):
@@ -39,9 +89,6 @@ class ScatterplotLayer(BaseLayer):
 
     _layer_type = traitlets.Unicode("scatterplot").tag(sync=True)
     _initial_view_state = traitlets.Dict().tag(sync=True)
-
-    # Number of rows per chunk for serializing table and accessor columns
-    _rows_per_chunk = traitlets.Int()
 
     table = PyarrowTableTrait(
         allowed_geometry_types={EXTENSION_NAME.POINT, EXTENSION_NAME.MULTIPOINT}
@@ -203,33 +250,9 @@ class ScatterplotLayer(BaseLayer):
     - Default: `1`.
     """
 
-    @classmethod
-    def from_geopandas(cls, gdf: gpd.GeoDataFrame, **kwargs) -> ScatterplotLayer:
-        """Construct a ScatterplotLayer from a geopandas GeoDataFrame.
-
-        The GeoDataFrame will be reprojected to EPSG:4326 if it is not already in that
-        coordinate system.
-
-        Args:
-            gdf: The GeoDataFrame to set on the layer.
-
-        Returns:
-            A ScatterplotLayer with the initialized data.
-        """
-        if gdf.crs and gdf.crs not in [EPSG_4326, OGC_84]:
-            warnings.warn("GeoDataFrame being reprojected to EPSG:4326")
-            gdf = gdf.to_crs(OGC_84)  # type: ignore
-
-        table = geopandas_to_geoarrow(gdf)
-        return cls(table=table, **kwargs)
-
     @traitlets.default("_initial_view_state")
     def _default_initial_view_state(self):
         return compute_view(self.table)
-
-    @traitlets.default("_rows_per_chunk")
-    def _default_rows_per_chunk(self):
-        return infer_rows_per_chunk(self.table)
 
     @traitlets.validate(
         "get_radius", "get_fill_color", "get_line_color", "get_line_width"
@@ -265,9 +288,6 @@ class PathLayer(BaseLayer):
 
     _layer_type = traitlets.Unicode("path").tag(sync=True)
     _initial_view_state = traitlets.Dict().tag(sync=True)
-
-    # Number of rows per chunk for serializing table and accessor columns
-    _rows_per_chunk = traitlets.Int()
 
     table = PyarrowTableTrait(
         allowed_geometry_types={
@@ -370,33 +390,9 @@ class PathLayer(BaseLayer):
     - Default: `1`.
     """
 
-    @classmethod
-    def from_geopandas(cls, gdf: gpd.GeoDataFrame, **kwargs) -> PathLayer:
-        """Construct a PathLayer from a geopandas GeoDataFrame.
-
-        The GeoDataFrame will be reprojected to EPSG:4326 if it is not already in that
-        coordinate system.
-
-        Args:
-            gdf: The GeoDataFrame to set on the layer.
-
-        Returns:
-            A PathLayer with the initialized data.
-        """
-        if gdf.crs and gdf.crs not in [EPSG_4326, OGC_84]:
-            warnings.warn("GeoDataFrame being reprojected to EPSG:4326")
-            gdf = gdf.to_crs(OGC_84)  # type: ignore
-
-        table = geopandas_to_geoarrow(gdf)
-        return cls(table=table, **kwargs)
-
     @traitlets.default("_initial_view_state")
     def _default_initial_view_state(self):
         return compute_view(self.table)
-
-    @traitlets.default("_rows_per_chunk")
-    def _default_rows_per_chunk(self):
-        return infer_rows_per_chunk(self.table)
 
     @traitlets.validate("get_color", "get_width")
     def _validate_accessor_length(self, proposal):
@@ -429,9 +425,6 @@ class SolidPolygonLayer(BaseLayer):
 
     _layer_type = traitlets.Unicode("solid-polygon").tag(sync=True)
     _initial_view_state = traitlets.Dict().tag(sync=True)
-
-    # Number of rows per chunk for serializing table and accessor columns
-    _rows_per_chunk = traitlets.Int()
 
     table = PyarrowTableTrait(
         allowed_geometry_types={EXTENSION_NAME.POLYGON, EXTENSION_NAME.MULTIPOLYGON}
@@ -524,33 +517,9 @@ class SolidPolygonLayer(BaseLayer):
     - Default: `[0, 0, 0, 255]`.
     """
 
-    @classmethod
-    def from_geopandas(cls, gdf: gpd.GeoDataFrame, **kwargs) -> SolidPolygonLayer:
-        """Construct a SolidPolygonLayer from a geopandas GeoDataFrame.
-
-        The GeoDataFrame will be reprojected to EPSG:4326 if it is not already in that
-        coordinate system.
-
-        Args:
-            gdf: The GeoDataFrame to set on the layer.
-
-        Returns:
-            A SolidPolygonLayer with the initialized data.
-        """
-        if gdf.crs and gdf.crs not in [EPSG_4326, OGC_84]:
-            warnings.warn("GeoDataFrame being reprojected to EPSG:4326")
-            gdf = gdf.to_crs(OGC_84)  # type: ignore
-
-        table = geopandas_to_geoarrow(gdf)
-        return cls(table=table, **kwargs)
-
     @traitlets.default("_initial_view_state")
     def _default_initial_view_state(self):
         return compute_view(self.table)
-
-    @traitlets.default("_rows_per_chunk")
-    def _default_rows_per_chunk(self):
-        return infer_rows_per_chunk(self.table)
 
     @traitlets.validate("get_elevation", "get_fill_color", "get_line_color")
     def _validate_accessor_length(self, proposal):

--- a/src/model.ts
+++ b/src/model.ts
@@ -8,7 +8,7 @@ import {
 } from "@geoarrow/deck.gl-layers";
 import * as arrow from "apache-arrow";
 import type { WidgetModel } from "@jupyter-widgets/base";
-import type { Layer } from "@deck.gl/core/typed";
+import type { Layer, LayerProps } from "@deck.gl/core/typed";
 import { parseParquetBuffers } from "./parquet";
 import { parseAccessor } from "./accessor";
 
@@ -16,10 +16,14 @@ export abstract class BaseGeoArrowModel {
   model: WidgetModel;
   callbacks: Map<string, () => void>;
 
+  pickable: LayerProps["pickable"] | null;
+
   constructor(model: WidgetModel, updateStateCallback: () => void) {
     this.model = model;
     this.model.on("change", updateStateCallback);
     this.callbacks = new Map();
+
+    this.initRegularAttribute("pickable", "pickable");
   }
 
   /**
@@ -161,7 +165,7 @@ export class ScatterplotModel extends BaseGeoArrowModel {
     return new GeoArrowScatterplotLayer({
       id: this.model.model_id,
       data: this.table,
-      pickable: true,
+      pickable: this.pickable,
 
       ...(this.radiusUnits && { radiusUnits: this.radiusUnits }),
       ...(this.radiusScale && { radiusScale: this.radiusScale }),
@@ -223,7 +227,7 @@ export class PathModel extends BaseGeoArrowModel {
     return new GeoArrowPathLayer({
       id: this.model.model_id,
       data: this.table,
-      pickable: true,
+      pickable: this.pickable,
 
       ...(this.widthUnits && { widthUnits: this.widthUnits }),
       ...(this.widthScale && { widthScale: this.widthScale }),
@@ -269,7 +273,7 @@ export class SolidPolygonModel extends BaseGeoArrowModel {
     return new GeoArrowSolidPolygonLayer({
       id: this.model.model_id,
       data: this.table,
-      pickable: true,
+      pickable: this.pickable,
 
       ...(this.filled && { filled: this.filled }),
       ...(this.extruded && { extruded: this.extruded }),


### PR DESCRIPTION
### Change list

- Move `_rows_per_chunk` and `from_geopandas` to the `BaseLayer` class.
- Add `pickable` boolean option (defaulting to `True`) to the base `BaseLayer` class, use `pickable` on the JS side to control layer interactivity.
- Render inherited members in the docs