### PR TITLE
Add pandas v2 requirement

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3899,4 +3899,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "87574bd7e75c7b7c261e0b62fda819a77424c3b83b0e519a15f2336be0b31b8e"
+content-hash = "0ae17f5ab693c9f8f66c29a589bb8b9a1aafa118ea9d6e83fc08ff3fab7fc65d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ python = "^3.8"
 anywidget = "^0.6.3"
 pyarrow = "^13.0.0"
 geopandas = ">=0.13"
+pandas = "^2"
 palettable = "^3.3.3"
 # We use the colormap module from matplotlib. This module may be vendored in the
 # future to remove the matplotlib dependency.


### PR DESCRIPTION
For https://github.com/developmentseed/lonboard/issues/224#event-10923390427

We currently assume the pandas version is >=2.

For now, we can set a pandas 2.0 requirement, but in the long term, pandas and geopandas will be optional dependencies. Maybe we conditionally import pandas and only use `dtype_backend` if the pandas version is >=2?