### PR TITLE
Deduce environment and set map height in colab and vscode

### DIFF
--- a/lonboard/_constants.py
+++ b/lonboard/_constants.py
@@ -15,3 +15,23 @@ class EXTENSION_NAME(bytes, Enum):
     MULTIPOINT = b"geoarrow.multipoint"
     MULTILINESTRING = b"geoarrow.multilinestring"
     MULTIPOLYGON = b"geoarrow.multipolygon"
+
+
+class Environment(str, Enum):
+    Azure = "azure"
+    """Azure notebook"""
+
+    Cocalc = "cocalc"
+    Colab = "colab"
+    """Colab notebook"""
+
+    Databricks = "databricks"
+
+    IPythonTerminal = "ipython_terminal"
+
+    Kaggle = "kaggle"
+    """Kaggle notebook"""
+
+    Nteract = "nteract"
+    Unknown = "unknown"
+    Vscode = "vscode"

--- a/lonboard/_environment.py
+++ b/lonboard/_environment.py
@@ -51,7 +51,7 @@ ENVIRONMENT = detect_environment()
 
 
 def default_height():
-    if ENVIRONMENT == Environment.Vscode:
+    if ENVIRONMENT in [Environment.Vscode, Environment.Colab]:
         return 500
 
     return None

--- a/lonboard/_environment.py
+++ b/lonboard/_environment.py
@@ -1,0 +1,60 @@
+import os
+
+from lonboard._constants import Environment
+
+try:
+    import IPython
+except ImportError:
+    IPython = None
+
+
+def detect_environment() -> Environment:
+    """Try to detect user's environment
+
+    This is ported from Plotly here:
+    https://github.com/plotly/plotly.py/blob/38ded4acc91bd6c33fbe2c8090d629ba2215dce1/packages/python/plotly/plotly/io/_renderers.py#L446C1-L538C37
+    under the MIT license.
+    """
+    if IPython and IPython.get_ipython():
+        try:
+            import google.colab  # noqa: F401
+
+            return Environment.Colab
+        except ImportError:
+            pass
+
+    if os.path.exists("/kaggle/input"):
+        return Environment.Kaggle
+
+    if "AZURE_NOTEBOOKS_HOST" in os.environ:
+        return Environment.Azure
+
+    if "VSCODE_PID" in os.environ:
+        return Environment.Vscode
+
+    if "NTERACT_EXE" in os.environ:
+        return Environment.Nteract
+
+    if "COCALC_PROJECT_ID" in os.environ:
+        return Environment.Cocalc
+
+    if "DATABRICKS_RUNTIME_VERSION" in os.environ:
+        return Environment.Databricks
+
+    if IPython.get_ipython().__class__.__name__ == "TerminalInteractiveShell":
+        return Environment.IPythonTerminal
+
+    return Environment.Unknown
+
+
+ENVIRONMENT = detect_environment()
+
+
+def default_height():
+    if ENVIRONMENT == Environment.Vscode:
+        return 500
+
+    return None
+
+
+DEFAULT_HEIGHT = default_height()

--- a/lonboard/_map.py
+++ b/lonboard/_map.py
@@ -8,6 +8,7 @@ import traitlets
 from ipywidgets.embed import embed_minimal_html
 
 from lonboard._base import BaseAnyWidget
+from lonboard._environment import DEFAULT_HEIGHT
 from lonboard._layer import BaseLayer
 from lonboard._viewport import compute_view
 
@@ -74,7 +75,9 @@ class Map(BaseAnyWidget):
     This API is not yet stabilized and may change in the future.
     """
 
-    _height = traitlets.Int(default_value=None, allow_none=True).tag(sync=True)
+    _height = traitlets.Int(default_value=DEFAULT_HEIGHT, allow_none=True).tag(
+        sync=True
+    )
     """Height of the map in pixels.
 
     This API is not yet stabilized and may change in the future.


### PR DESCRIPTION
Closes https://github.com/developmentseed/lonboard/issues/249. 

The goal is for automatic map height inference in JupyterLab so that the map will fill all available height when using sidecar. Hopefully this will let us customize what defaults to set where in a way that works everywhere 🤷‍♂️ 