### PR TITLE
Add various carto basemaps as options

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 A Python library for fast, interactive geospatial vector data visualization in Jupyter.
 
-By utilizing new technologies like [GeoArrow](https://github.com/geoarrow/geoarrow) and [GeoParquet](https://github.com/opengeospatial/geoparquet) in conjunction with [GPU-based map rendering](https://deck.gl/), lonboard aims to enable visualizing large geospatial datasets interactively through a simple interface.
+Building on cutting-edge technologies like [GeoArrow](https://github.com/geoarrow/geoarrow) and [GeoParquet](https://github.com/opengeospatial/geoparquet) in conjunction with [GPU-based map rendering](https://deck.gl/), lonboard aims to enable visualizing large geospatial datasets interactively through a simple interface.
 
 ![](assets/hero-image.jpg)
 

--- a/build.mjs
+++ b/build.mjs
@@ -12,4 +12,7 @@ esbuild.build({
   define: {
     "define.amd": "false",
   },
+  // Code splitting didn't work initially because it tried to load from a local
+  // relative path ./chunk.js
+  // splitting: true,
 });

--- a/docs/api/basemap.md
+++ b/docs/api/basemap.md
@@ -1,0 +1,3 @@
+# lonboard.basemap
+
+::: lonboard.basemap.CartoBasemap

--- a/lonboard/_map.py
+++ b/lonboard/_map.py
@@ -11,6 +11,7 @@ from lonboard._base import BaseAnyWidget
 from lonboard._environment import DEFAULT_HEIGHT
 from lonboard._layer import BaseLayer
 from lonboard._viewport import compute_view
+from lonboard.basemap import CartoBasemap
 
 # bundler yields lonboard/static/{index.js,styles.css}
 bundler_output_dir = Path(__file__).parent / "static"
@@ -106,6 +107,17 @@ class Map(BaseAnyWidget):
 
     - Type: `int`
     - Default: `5`
+    """
+
+    basemap_style = traitlets.Unicode(CartoBasemap.PositronWithoutLabels).tag(sync=True)
+    """
+    A MapLibre-compatible basemap style.
+
+    Various styles are provided in [`lonboard.basemap`][lonboard.basemap].
+
+    - Type: `str`
+    - Default
+      [`lonboard.basemap.CartoBasemap.PositronWithoutLabels`][lonboard.basemap.CartoBasemap.PositronWithoutLabels]
     """
 
     def to_html(self, filename: Union[str, Path]) -> None:

--- a/lonboard/_map.py
+++ b/lonboard/_map.py
@@ -109,7 +109,7 @@ class Map(BaseAnyWidget):
     - Default: `5`
     """
 
-    basemap_style = traitlets.Unicode(CartoBasemap.PositronWithoutLabels).tag(sync=True)
+    basemap_style = traitlets.Unicode(CartoBasemap.PositronNoLabels).tag(sync=True)
     """
     A MapLibre-compatible basemap style.
 
@@ -117,7 +117,7 @@ class Map(BaseAnyWidget):
 
     - Type: `str`
     - Default
-      [`lonboard.basemap.CartoBasemap.PositronWithoutLabels`][lonboard.basemap.CartoBasemap.PositronWithoutLabels]
+      [`lonboard.basemap.CartoBasemap.PositronNoLabels`][lonboard.basemap.CartoBasemap.PositronNoLabels]
     """
 
     def to_html(self, filename: Union[str, Path]) -> None:

--- a/lonboard/basemap.py
+++ b/lonboard/basemap.py
@@ -15,7 +15,7 @@ class CartoBasemap(str, Enum):
     ![](https://carto.com/help/images/building-maps/basemaps/dark_labels.png)
     """
 
-    DarkMatterWithoutLabels = (
+    DarkMatterNoLabels = (
         "https://basemaps.cartocdn.com/gl/dark-matter-nolabels-gl-style/style.json"
     )
     """A dark map style without labels."""
@@ -26,7 +26,7 @@ class CartoBasemap(str, Enum):
     ![](https://carto.com/help/images/building-maps/basemaps/positron_labels.png)
     """
 
-    PositronWithoutLabels = (
+    PositronNoLabels = (
         "https://basemaps.cartocdn.com/gl/positron-nolabels-gl-style/style.json"
     )
     """A light map style without labels."""
@@ -37,7 +37,7 @@ class CartoBasemap(str, Enum):
     ![](https://carto.com/help/images/building-maps/basemaps/voyager_labels.png)
     """
 
-    VoyagerWithoutLabels = (
+    VoyagerNoLabels = (
         "https://basemaps.cartocdn.com/gl/voyager-nolabels-gl-style/style.json"
     )
     """A light, colored map style without labels."""

--- a/lonboard/basemap.py
+++ b/lonboard/basemap.py
@@ -1,0 +1,43 @@
+from enum import Enum
+
+
+class CartoBasemap(str, Enum):
+    """Basemap styles provided by Carto.
+
+    Refer to [Carto
+    documentation](https://docs.carto.com/carto-for-developers/carto-for-react/guides/basemaps)
+    for information on styles.
+    """
+
+    DarkMatter = "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json"
+    """A dark map style with labels.
+
+    ![](https://carto.com/help/images/building-maps/basemaps/dark_labels.png)
+    """
+
+    DarkMatterWithoutLabels = (
+        "https://basemaps.cartocdn.com/gl/dark-matter-nolabels-gl-style/style.json"
+    )
+    """A dark map style without labels."""
+
+    Positron = "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
+    """A light map style with labels.
+
+    ![](https://carto.com/help/images/building-maps/basemaps/positron_labels.png)
+    """
+
+    PositronWithoutLabels = (
+        "https://basemaps.cartocdn.com/gl/positron-nolabels-gl-style/style.json"
+    )
+    """A light map style without labels."""
+
+    Voyager = "https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json"
+    """A light, colored map style with labels.
+
+    ![](https://carto.com/help/images/building-maps/basemaps/voyager_labels.png)
+    """
+
+    VoyagerWithoutLabels = (
+        "https://basemaps.cartocdn.com/gl/voyager-nolabels-gl-style/style.json"
+    )
+    """A light, colored map style without labels."""

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
           - api/layers/path-layer.md
           - api/layers/scatterplot-layer.md
           - api/layers/solid-polygon-layer.md
+      - api/basemap.md
       - api/colormap.md
       - api/traits.md
       - Experimental:

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       "devDependencies": {
         "@jupyter-widgets/base": "^6.0.6",
         "@types/react": "^18.2.35",
+        "@types/uuid": "^9.0.7",
         "esbuild": "^0.19.5",
         "nodemon": "^3.0.1",
         "prettier": "^3.1.0",
@@ -1749,6 +1750,12 @@
       "version": "1.11.12",
       "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.11.12.tgz",
       "integrity": "sha512-beX81q12OQo809WJ/UYCvUDvJR3YQ4wtehYYQ6eNw5VLyd+KUNBRV4FgzZCHBmACbdPulH9F9ifhxzFFU9TWvQ==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
+      "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g==",
       "dev": true
     },
     "node_modules/@vitest/expect": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-map-gl": "^7.1.5",
     "uuid": "^9.0.1"
   },
+  "type": "module",
   "devDependencies": {
     "@jupyter-widgets/base": "^6.0.6",
     "@types/react": "^18.2.35",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@jupyter-widgets/base": "^6.0.6",
     "@types/react": "^18.2.35",
+    "@types/uuid": "^9.0.7",
     "esbuild": "^0.19.5",
     "nodemon": "^3.0.1",
     "prettier": "^3.1.0",

--- a/src/accessor.ts
+++ b/src/accessor.ts
@@ -1,5 +1,5 @@
 import * as arrow from "apache-arrow";
-import { parseParquetBuffers } from "./parquet";
+import { parseParquetBuffers } from "./parquet.js";
 import { useState, useEffect } from "react";
 
 export function useTableBufferState(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -127,7 +127,6 @@ function App() {
 
   return (
     <div id={`map-${mapId}`} style={{ height: mapHeight || "100%" }}>
-      {/* @ts-expect-error */}
       <DeckGL
         initialViewState={
           ["longitude", "latitude", "zoom"].every((key) =>
@@ -141,7 +140,6 @@ function App() {
         getTooltip={showTooltip && getTooltip}
         pickingRadius={pickingRadius}
       >
-        {/* @ts-expect-error */}
         <Map mapStyle={mapStyle || DEFAULT_MAP_STYLE} />
       </DeckGL>
     </div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -142,9 +142,7 @@ function App() {
         pickingRadius={pickingRadius}
       >
         {/* @ts-expect-error */}
-        <Map
-          mapStyle={mapStyle || DEFAULT_MAP_STYLE}
-        />
+        <Map mapStyle={mapStyle || DEFAULT_MAP_STYLE} />
       </DeckGL>
     </div>
   );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,11 +4,11 @@ import { createRender, useModelState, useModel } from "@anywidget/react";
 import Map from "react-map-gl/maplibre";
 import DeckGL from "@deck.gl/react/typed";
 import type { Layer } from "@deck.gl/core/typed";
-import { BaseLayerModel, initializeLayer } from "./model";
+import { BaseLayerModel, initializeLayer } from "./model/index.js";
 import type { WidgetModel } from "@jupyter-widgets/base";
-import { useParquetWasm } from "./parquet";
-import { getTooltip } from "./tooltip";
-import { loadChildModels } from "./util";
+import { useParquetWasm } from "./parquet.js";
+import { getTooltip } from "./tooltip/index.js";
+import { loadChildModels } from "./util.js";
 import { v4 as uuidv4 } from "uuid";
 
 const DEFAULT_INITIAL_VIEW_STATE = {
@@ -19,7 +19,7 @@ const DEFAULT_INITIAL_VIEW_STATE = {
   pitch: 0,
 };
 
-const MAP_STYLE =
+const DEFAULT_MAP_STYLE =
   "https://basemaps.cartocdn.com/gl/positron-nolabels-gl-style/style.json";
 
 async function getChildModelState(
@@ -59,6 +59,7 @@ async function getChildModelState(
 function App() {
   let [parquetWasmReady] = useParquetWasm();
   let [initialViewState] = useModelState<DataView>("_initial_view_state");
+  let [mapStyle] = useModelState<string>("basemap_style");
   let [mapHeight] = useModelState<number>("_height");
   let [showTooltip] = useModelState<boolean>("show_tooltip");
   let [pickingRadius] = useModelState<number>("picking_radius");
@@ -126,6 +127,7 @@ function App() {
 
   return (
     <div id={`map-${mapId}`} style={{ height: mapHeight || "100%" }}>
+      {/* @ts-expect-error */}
       <DeckGL
         initialViewState={
           ["longitude", "latitude", "zoom"].every((key) =>
@@ -139,7 +141,10 @@ function App() {
         getTooltip={showTooltip && getTooltip}
         pickingRadius={pickingRadius}
       >
-        <Map mapStyle={MAP_STYLE} />
+        {/* @ts-expect-error */}
+        <Map
+          mapStyle={mapStyle || DEFAULT_MAP_STYLE}
+        />
       </DeckGL>
     </div>
   );

--- a/src/model/base.ts
+++ b/src/model/base.ts
@@ -1,5 +1,5 @@
 import type { WidgetModel } from "@jupyter-widgets/base";
-import { parseAccessor } from "../accessor";
+import { parseAccessor } from "../accessor.js";
 
 export abstract class BaseModel {
   protected model: WidgetModel;

--- a/src/model/extension.ts
+++ b/src/model/extension.ts
@@ -6,7 +6,7 @@ import {
   CollisionFilterExtension as _CollisionFilterExtension,
 } from "@deck.gl/extensions/typed";
 import type { WidgetModel } from "@jupyter-widgets/base";
-import { BaseModel } from "./base";
+import { BaseModel } from "./base.js";
 
 export abstract class BaseExtensionModel extends BaseModel {
   static extensionType: string;

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -1,14 +1,14 @@
-export { BaseModel } from "./base";
+export { BaseModel } from "./base.js";
 export {
   BaseLayerModel,
   PathModel,
   ScatterplotModel,
   SolidPolygonModel,
   initializeLayer,
-} from "./layer";
+} from "./layer.js";
 export {
   BaseExtensionModel,
   BrushingExtension,
   CollisionFilterExtension,
   initializeExtension,
-} from "./extension";
+} from "./extension.js";

--- a/src/model/layer.ts
+++ b/src/model/layer.ts
@@ -17,10 +17,10 @@ import {
 } from "@geoarrow/deck.gl-layers";
 import type { WidgetModel } from "@jupyter-widgets/base";
 import * as arrow from "apache-arrow";
-import { parseParquetBuffers } from "../parquet";
-import { loadChildModels } from "../util";
-import { BaseModel } from "./base";
-import { BaseExtensionModel, initializeExtension } from "./extension";
+import { parseParquetBuffers } from "../parquet.js";
+import { loadChildModels } from "../util.js";
+import { BaseModel } from "./base.js";
+import { BaseExtensionModel, initializeExtension } from "./extension.js";
 
 export abstract class BaseLayerModel extends BaseModel {
   protected table: arrow.Table;

--- a/src/tooltip/index.ts
+++ b/src/tooltip/index.ts
@@ -1,5 +1,5 @@
-import { TooltipContent } from "@deck.gl/core/typed/lib/tooltip";
-import { GeoArrowPickingInfo } from "@geoarrow/deck.gl-layers/dist/types";
+import { TooltipContent } from "@deck.gl/core/typed/lib/tooltip.js";
+import type { GeoArrowPickingInfo } from "@geoarrow/deck.gl-layers";
 
 import "./index.css";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,9 @@
   "include": ["src/**/*"],
   "exclude": ["node_modules"],
   "compilerOptions": {
-    "moduleResolution": "nodenext",
-    "module": "NodeNext",
+    // Note: setting these two to NodeNext this breaks typing for apache-arrow
+    "moduleResolution": "node",
+    // "module": "NodeNext",
     "outDir": "./dist",
     "allowJs": true,
     "target": "ES2020",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "include": ["src/**/*"],
   "exclude": ["node_modules"],
   "compilerOptions": {
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
+    "module": "NodeNext",
     "outDir": "./dist",
     "allowJs": true,
     "target": "ES2020",


### PR DESCRIPTION
### Change list

- Add `basemap_style` attribute
- Add enum with carto styles (closes https://github.com/developmentseed/lonboard/issues/265)
- Change tsconfig to use nodenext module resolution
- Explore bundle splitting to load maplibre-gl separately, but didn't work out of the box 😕 Ref https://visgl.github.io/react-map-gl/docs/api-reference/map#maplib