### PR TITLE
Data filter extension

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-added-large-files
-        args: ['--maxkb=2000']
+        args: ['--maxkb=5500']
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.3

--- a/docs/api/layer-extensions/brushing-extension.md
+++ b/docs/api/layer-extensions/brushing-extension.md
@@ -1,5 +1,9 @@
 # BrushingExtension
 
+![](../../assets/arc-layer-migration-example.gif)
+
+> Screen recording from [U.S. County-to-County Migration example](../../../examples/migration/).
+
 ::: lonboard.experimental.BrushingExtension
     options:
       show_bases: false

--- a/docs/api/layer-extensions/data-filter-extension.md
+++ b/docs/api/layer-extensions/data-filter-extension.md
@@ -1,0 +1,6 @@
+# DataFilterExtension
+
+::: lonboard.experimental.DataFilterExtension
+    options:
+      show_bases: false
+      inherited_members: true

--- a/docs/api/layer-extensions/index.md
+++ b/docs/api/layer-extensions/index.md
@@ -1,0 +1,9 @@
+# Layer Extensions
+
+Layer extensions are bonus features that you can optionally add to the core deck.gl layers.
+
+Layer extensions are in an experimental state. Some things are known to not yet work:
+
+- Modifying the extensions on a layer by mutating its `extensions` list via `append` or `pop`. It should work, however, by creating a new list and assigning `layer.extensions = new_extensions_list`.
+
+If you encounter issues, please [create an issue](https://github.com/developmentseed/lonboard/issues/new) with reproducible steps.

--- a/docs/api/layers/arc-layer.md
+++ b/docs/api/layers/arc-layer.md
@@ -1,5 +1,9 @@
 # ArcLayer
 
+![](../../assets/arc-layer-migration-example.gif)
+
+> Screen recording from [U.S. County-to-County Migration example](../../../examples/migration/).
+
 ::: lonboard.experimental.ArcLayer
     options:
       inherited_members: true

--- a/examples/migration.ipynb
+++ b/examples/migration.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "ef775cd2",
    "metadata": {},
    "source": [
     "# U.S. County-to-County Migration\n",
@@ -15,6 +16,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b73b22ff",
    "metadata": {},
    "source": [
     "## Imports"
@@ -41,6 +43,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "35467684",
    "metadata": {},
    "source": [
     "Fetch the data from the version in the `deck.gl-data` repository."
@@ -60,6 +63,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5a68a643",
    "metadata": {},
    "source": [
     "The following cell may be a little hard to follow, but what it's doing is taking the raw data, which represents a [_graph_](https://en.wikipedia.org/wiki/Graph_(abstract_data_type)) of the data and normalizing it to a table structure where each row represents one \"arc\" between a source and target county.\n",
@@ -152,6 +156,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fe0cdb22",
    "metadata": {},
    "source": [
     "We define some color constants, as well as a color lookup array.\n",
@@ -184,6 +189,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "ccffe287",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,15 +207,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
+   "id": "13b8b182",
    "metadata": {},
    "outputs": [],
    "source": [
-    "brushing_extension = BrushingExtension(brushing_radius=200000)"
+    "brushing_extension = BrushingExtension()\n",
+    "brushing_radius = 200000"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "be8475b7",
    "metadata": {},
    "source": [
     "Convert the `sources` list of dictionaries into a GeoPandas `GeoDataFrame` to pass into a `ScatterplotLayer`."
@@ -217,7 +226,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
+   "id": "8e0c2fd9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -235,6 +245,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "506ba6a7",
    "metadata": {},
    "source": [
     "Create a `ScatterplotLayer` for source points:"
@@ -242,7 +253,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
+   "id": "86799a4c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -252,12 +264,14 @@
     "    radius_scale=3000,\n",
     "    pickable=False,\n",
     "    extensions=[brushing_extension],\n",
+    "    brushing_radius=brushing_radius,\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
+   "id": "570868b8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -275,6 +289,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bf29c60d",
    "metadata": {},
    "source": [
     "Create a `ScatterplotLayer` for target points:"
@@ -282,7 +297,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
+   "id": "56b9dcf2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -295,11 +311,13 @@
     "    filled=False,\n",
     "    line_width_min_pixels=2,\n",
     "    extensions=[brushing_extension],\n",
+    "    brushing_radius=brushing_radius,\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "a76b8b32",
    "metadata": {},
    "source": [
     "Note: the `ArcLayer` can't currently be created from a GeoDataFrame because it\n",
@@ -311,7 +329,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
+   "id": "6400bd35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -330,11 +349,13 @@
     "    opacity=0.4,\n",
     "    pickable=False,\n",
     "    extensions=[brushing_extension],\n",
+    "    brushing_radius=brushing_radius,\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "9405a902",
    "metadata": {},
    "source": [
     "Now we can create a map using these three layers we've created.\n",
@@ -346,21 +367,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
+   "id": "5ef02c61",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c8b35b9909c148758cb6297a79a8e89e",
+       "model_id": "528e69ea2bac4278a26f1215a74ccf75",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Map(layers=[ScatterplotLayer(extensions=[BrushingExtension(brushing_radius=200000.0)], get_fill_color=<pyarrow…"
+       "Map(layers=[ScatterplotLayer(brushing_radius=200000.0, extensions=[BrushingExtension()], get_fill_color=<pyarr…"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -373,6 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "49fff4c0",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/lonboard/_base.py
+++ b/lonboard/_base.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 import traitlets
 from anywidget import AnyWidget
 from ipywidgets import Widget
@@ -28,5 +30,5 @@ class BaseAnyWidget(AnyWidget):
 
 
 class BaseExtension(Widget):
-    _rows_per_chunk = traitlets.Int()
-    """Number of rows per chunk for serializing table and accessor columns."""
+    _layer_traits: Dict[str, traitlets.TraitType] = {}
+    """Traits from this extension to dynamically assign onto a layer."""

--- a/lonboard/_base.py
+++ b/lonboard/_base.py
@@ -29,6 +29,6 @@ class BaseAnyWidget(AnyWidget):
         super().__init__(**kwargs)
 
 
-class BaseExtension(Widget):
+class BaseExtension(BaseWidget):
     _layer_traits: Dict[str, traitlets.TraitType] = {}
     """Traits from this extension to dynamically assign onto a layer."""

--- a/lonboard/_base.py
+++ b/lonboard/_base.py
@@ -1,3 +1,4 @@
+import traitlets
 from anywidget import AnyWidget
 from ipywidgets import Widget
 
@@ -27,4 +28,5 @@ class BaseAnyWidget(AnyWidget):
 
 
 class BaseExtension(Widget):
-    pass
+    _rows_per_chunk = traitlets.Int()
+    """Number of rows per chunk for serializing table and accessor columns."""

--- a/lonboard/_layer.py
+++ b/lonboard/_layer.py
@@ -48,7 +48,6 @@ class BaseLayer(BaseWidget):
         # Assign any extension properties that we took out before calling __init__
         added_names: List[str] = []
         for prop_name, prop_value in extension_kwargs.items():
-            print("set_trait", prop_name, prop_value)
             self.set_trait(prop_name, prop_value)
             added_names.append(prop_name)
 
@@ -59,6 +58,10 @@ class BaseLayer(BaseWidget):
     extensions = traitlets.List(trait=traitlets.Instance(BaseExtension)).tag(
         sync=True, **ipywidgets.widget_serialization
     )
+    """
+    A list of [layer extension](https://developmentseed.org/lonboard/latest/api/layer-extensions/)
+    objects to add additional features to a layer.
+    """
 
     # TODO: the extensions list is not observed; separately, the list object itself does
     # not propagate events, so an append wouldn't work.

--- a/lonboard/_layer.py
+++ b/lonboard/_layer.py
@@ -33,7 +33,7 @@ class BaseLayer(BaseWidget):
 
     # The following traitlets **are** serialized to JS
 
-    def __init__(self, *, extensions: Sequence[BaseExtension], **kwargs):
+    def __init__(self, *, extensions: Sequence[BaseExtension] = (), **kwargs):
         # We allow layer extensions to dynamically inject properties onto the layer
         # widgets where the layer is defined. We wish to allow extensions and their
         # properties to be passed in the layer constructor. _However_, if

--- a/lonboard/_map.py
+++ b/lonboard/_map.py
@@ -130,7 +130,7 @@ class Map(BaseAnyWidget):
     """
     A MapLibre-compatible basemap style.
 
-    Various styles are provided in [`lonboard.basemap`][lonboard.basemap].
+    Various styles are provided in [`lonboard.basemap`](https://developmentseed.org/lonboard/latest/api/basemap/).
 
     - Type: `str`
     - Default

--- a/lonboard/_serialization.py
+++ b/lonboard/_serialization.py
@@ -14,9 +14,7 @@ DEFAULT_PARQUET_CHUNK_SIZE = 2**16
 DEFAULT_ARROW_CHUNK_BYTES_SIZE = 5 * 1024 * 1024  # 5MB
 
 
-def serialize_table_to_parquet(
-    table: pa.Table, *, max_chunksize: int = DEFAULT_PARQUET_CHUNK_SIZE
-) -> List[bytes]:
+def serialize_table_to_parquet(table: pa.Table, *, max_chunksize: int) -> List[bytes]:
     buffers: List[bytes] = []
     for record_batch in table.to_batches(max_chunksize=max_chunksize):
         with BytesIO() as bio:
@@ -27,11 +25,12 @@ def serialize_table_to_parquet(
                 compression_level=DEFAULT_PARQUET_COMPRESSION_LEVEL,
             ) as writer:
                 # Occasionally it's possible for there to be empty batches in the
-                # pyarrow table. This will error when writing to parquet.
-                if record_batch.num_rows > 0:
-                    writer.write_batch(
-                        record_batch, row_group_size=record_batch.num_rows
-                    )
+                # pyarrow table. This will error when writing to parquet. We want to
+                # give a more informative error.
+                if record_batch.num_rows == 0:
+                    raise ValueError("Batch with 0 rows.")
+
+                writer.write_batch(record_batch, row_group_size=record_batch.num_rows)
 
             buffers.append(bio.getvalue())
 

--- a/lonboard/_serialization.py
+++ b/lonboard/_serialization.py
@@ -26,7 +26,12 @@ def serialize_table_to_parquet(
                 compression=DEFAULT_PARQUET_COMPRESSION,
                 compression_level=DEFAULT_PARQUET_COMPRESSION_LEVEL,
             ) as writer:
-                writer.write_batch(record_batch, row_group_size=record_batch.num_rows)
+                # Occasionally it's possible for there to be empty batches in the
+                # pyarrow table. This will error when writing to parquet.
+                if record_batch.num_rows > 0:
+                    writer.write_batch(
+                        record_batch, row_group_size=record_batch.num_rows
+                    )
 
             buffers.append(bio.getvalue())
 

--- a/lonboard/_serialization.py
+++ b/lonboard/_serialization.py
@@ -16,6 +16,8 @@ DEFAULT_ARROW_CHUNK_BYTES_SIZE = 5 * 1024 * 1024  # 5MB
 
 def serialize_table_to_parquet(table: pa.Table, *, max_chunksize: int) -> List[bytes]:
     buffers: List[bytes] = []
+    # NOTE: passing `max_chunksize=0` creates an infinite loop
+    # https://github.com/apache/arrow/issues/39788
     for record_batch in table.to_batches(max_chunksize=max_chunksize):
         with BytesIO() as bio:
             with pq.ParquetWriter(

--- a/lonboard/_utils.py
+++ b/lonboard/_utils.py
@@ -1,9 +1,10 @@
-from typing import TypeVar
+from typing import Any, Dict, Sequence, TypeVar
 
 import numpy as np
 import pandas as pd
 import pyarrow as pa
 
+from lonboard._base import BaseExtension
 from lonboard._constants import EXTENSION_NAME
 
 DF = TypeVar("DF", bound=pd.DataFrame)
@@ -70,3 +71,22 @@ def auto_downcast(df: DF) -> DF:
         )
 
     return df
+
+
+def remove_extension_kwargs(
+    extensions: Sequence[BaseExtension], kwargs: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Remove extension properties from kwargs, returning the removed properties.
+
+    **This mutates the kwargs input.**
+    """
+    extension_kwargs: Dict[str, Any] = {}
+    if extensions:
+        for extension in extensions:
+            for extension_prop_name in extension._layer_traits.keys():
+                if extension_prop_name in kwargs:
+                    extension_kwargs[extension_prop_name] = kwargs.pop(
+                        extension_prop_name
+                    )
+
+    return extension_kwargs

--- a/lonboard/experimental/__init__.py
+++ b/lonboard/experimental/__init__.py
@@ -5,4 +5,8 @@ unexpected behavior when using them.
 """
 
 from ._layer import ArcLayer, TextLayer
-from .layer_extension import BrushingExtension, CollisionFilterExtension
+from .layer_extension import (
+    BrushingExtension,
+    CollisionFilterExtension,
+    DataFilterExtension,
+)

--- a/lonboard/experimental/layer_extension.py
+++ b/lonboard/experimental/layer_extension.py
@@ -114,6 +114,12 @@ class DataFilterExtension(BaseExtension):
 
     _layer_traits = {
         "get_filter_value": FloatAccessor(None, allow_none=False),
+        "filter_range": traitlets.Tuple(
+            traitlets.Float(), traitlets.Float(), default_value=(-1, 1)
+        ).tag(sync=True),
+        "filter_soft_range": traitlets.Tuple(
+            traitlets.Float(), traitlets.Float(), default_value=None, allow_none=True
+        ).tag(sync=True),
     }
 
     filter_enabled = traitlets.Bool(True).tag(sync=True)

--- a/lonboard/experimental/layer_extension.py
+++ b/lonboard/experimental/layer_extension.py
@@ -90,23 +90,31 @@ class CollisionFilterExtension(BaseExtension):
     """
 
 
+# TODO: support filterSize > 1
 class DataFilterExtension(BaseExtension):
     """
     Adds GPU-based data filtering functionalities to layers. It allows the layer to
     show/hide objects based on user-defined properties.
-    """
 
-    _extension_type = traitlets.Unicode("data-filter").tag(sync=True)
+    ### Layer Parameters
 
-    # TODO: support filterSize > 1
-    get_filter_value = FloatAccessor(allow_none=False)
-    """Accessor to retrieve the value for each object that it will be filtered by.
+    ```
+    get_filter_value = FloatAccessor(None, allow_none=False)
+    ```
+
+    Accessor to retrieve the value for each object that it will be filtered by.
 
     - Type: [FloatAccessor][lonboard.traits.FloatAccessor]
         - If a number is provided, it is used as the value for all objects.
         - If an array is provided, each value in the array will be used as the value
           for the object at the same row index.
     """
+
+    _extension_type = traitlets.Unicode("data-filter").tag(sync=True)
+
+    _layer_traits = {
+        "get_filter_value": FloatAccessor(None, allow_none=False),
+    }
 
     filter_enabled = traitlets.Bool(True).tag(sync=True)
     """

--- a/lonboard/experimental/layer_extension.py
+++ b/lonboard/experimental/layer_extension.py
@@ -12,7 +12,15 @@ class BrushingExtension(BaseExtension):
 
     _extension_type = traitlets.Unicode("brushing").tag(sync=True)
 
-    brushing_enabled = traitlets.Bool(True).tag(sync=True)
+    _layer_traits = {
+        "brushing_enabled": traitlets.Bool(True).tag(sync=True),
+        "brushing_target": traitlets.Unicode("source", allow_none=True).tag(sync=True),
+        "brushing_radius": traitlets.Float(allow_none=True, min=0).tag(sync=True),
+        # TODO: update trait
+        "get_brushing_target": traitlets.Any(allow_none=True).tag(sync=True),
+    }
+
+    # brushing_enabled = traitlets.Bool(True).tag(sync=True)
     """
     Enable/disable brushing. If brushing is disabled, all objects are rendered.
 
@@ -20,7 +28,7 @@ class BrushingExtension(BaseExtension):
     - Default: `True`
     """
 
-    brushing_target = traitlets.Unicode("source", allow_none=True).tag(sync=True)
+    # brushing_target = traitlets.Unicode("source", allow_none=True).tag(sync=True)
     """
     The position used to filter each object by.
 
@@ -32,7 +40,7 @@ class BrushingExtension(BaseExtension):
 
     """
 
-    brushing_radius = traitlets.Float(allow_none=True, min=0).tag(sync=True)
+    # brushing_radius = traitlets.Float(allow_none=True, min=0).tag(sync=True)
     """
     The brushing radius centered at the pointer, in meters. If a data object is within
     this circle, it is rendered; otherwise it is hidden.
@@ -42,7 +50,7 @@ class BrushingExtension(BaseExtension):
     """
 
     # TODO: update trait
-    get_brushing_target = traitlets.Any(allow_none=True).tag(sync=True)
+    # get_brushing_target = traitlets.Any(allow_none=True).tag(sync=True)
     """
     Called to retrieve an arbitrary position for each object that it will be filtered
     by.
@@ -56,19 +64,25 @@ class CollisionFilterExtension(BaseExtension):
 
     _extension_type = traitlets.Unicode("collision-filter").tag(sync=True)
 
+    _layer_traits = {
+        "collision_enabled": traitlets.Bool(True).tag(sync=True),
+        "collision_group": traitlets.Unicode().tag(sync=True),
+        "get_collision_priority": FloatAccessor(allow_none=True),
+    }
+
     #   /**
     #    * Props to override when rendering collision map
     #    */
     #   collisionTestProps?: {};
 
-    collision_enabled = traitlets.Bool(True).tag(sync=True)
+    # collision_enabled = traitlets.Bool(True).tag(sync=True)
     """Enable/disable collisions. If collisions are disabled, all objects are rendered.
 
     - Type: `bool`, optional
     - Default: `True`
     """
 
-    collision_group = traitlets.Unicode().tag(sync=True)
+    # collision_group = traitlets.Unicode().tag(sync=True)
     """
     Collision group this layer belongs to. If it is not set, the 'default' collision
     group is used
@@ -77,7 +91,7 @@ class CollisionFilterExtension(BaseExtension):
     - Default: `None`
     """
 
-    get_collision_priority = FloatAccessor(allow_none=True)
+    # get_collision_priority = FloatAccessor(allow_none=True)
     """
     Accessor for collision priority. Must return a number in the range -1000 -> 1000.
     Features with higher values are shown preferentially.
@@ -90,7 +104,6 @@ class CollisionFilterExtension(BaseExtension):
     """
 
 
-# TODO: support filterSize > 1
 class DataFilterExtension(BaseExtension):
     """
     Adds GPU-based data filtering functionalities to layers. It allows the layer to
@@ -113,16 +126,33 @@ class DataFilterExtension(BaseExtension):
     _extension_type = traitlets.Unicode("data-filter").tag(sync=True)
 
     _layer_traits = {
-        "get_filter_value": FloatAccessor(None, allow_none=False),
+        "filter_enabled": traitlets.Bool(True).tag(sync=True),
         "filter_range": traitlets.Tuple(
             traitlets.Float(), traitlets.Float(), default_value=(-1, 1)
         ).tag(sync=True),
         "filter_soft_range": traitlets.Tuple(
             traitlets.Float(), traitlets.Float(), default_value=None, allow_none=True
         ).tag(sync=True),
+        "filter_transform_size": traitlets.Bool(True).tag(sync=True),
+        "filter_transform_color": traitlets.Bool(True).tag(sync=True),
+        "get_filter_value": FloatAccessor(None, allow_none=False),
     }
 
-    filter_enabled = traitlets.Bool(True).tag(sync=True)
+    # TODO: support filterSize > 1
+    # In order to support filterSize > 1, we need to allow the get_filter_value accessor
+    # to be either a single float or a fixed size list of up to 4 floats.
+
+    # filter_size = traitlets.Int(1).tag(sync=True)
+    """The size of the filter (number of columns to filter by).
+
+    The data filter can show/hide data based on 1-4 numeric properties of each object.
+
+    - Type: `int`, optional
+    - Default 1.
+    """
+
+    # TODO: document in constructor and then remove.
+    # filter_enabled = traitlets.Bool(True).tag(sync=True)
     """
     Enable/disable the data filter. If the data filter is disabled, all objects are
     rendered.
@@ -131,9 +161,9 @@ class DataFilterExtension(BaseExtension):
     - Default: `True`
     """
 
-    filter_range = traitlets.Tuple(
-        traitlets.Float(), traitlets.Float(), default_value=(-1, 1)
-    ).tag(sync=True)
+    # filter_range = traitlets.Tuple(
+    #     traitlets.Float(), traitlets.Float(), default_value=(-1, 1)
+    # ).tag(sync=True)
     """The (min, max) bounds which defines whether an object should be rendered.
 
     If an object's filtered value is within the bounds, the object will be rendered;
@@ -143,9 +173,9 @@ class DataFilterExtension(BaseExtension):
     - Default: `(-1, 1)`
     """
 
-    filter_soft_range = traitlets.Tuple(
-        traitlets.Float(), traitlets.Float(), default_value=None, allow_none=True
-    ).tag(sync=True)
+    # filter_soft_range = traitlets.Tuple(
+    #     traitlets.Float(), traitlets.Float(), default_value=None, allow_none=True
+    # ).tag(sync=True)
     """If specified, objects will be faded in/out instead of abruptly shown/hidden.
 
     When the filtered value is outside of the bounds defined by `filter_soft_range` but
@@ -156,7 +186,7 @@ class DataFilterExtension(BaseExtension):
     - Default: `None`
     """
 
-    filter_transform_size = traitlets.Bool(True).tag(sync=True)
+    # filter_transform_size = traitlets.Bool(True).tag(sync=True)
     """
     When an object is "faded", manipulate its size so that it appears smaller or
     thinner. Only works if `filter_soft_range` is specified.
@@ -165,7 +195,7 @@ class DataFilterExtension(BaseExtension):
     - Default: `True`
     """
 
-    filter_transform_color = traitlets.Bool(True).tag(sync=True)
+    # filter_transform_color = traitlets.Bool(True).tag(sync=True)
     """
     When an object is "faded", manipulate its opacity so that it appears more
     translucent. Only works if `filter_soft_range` is specified.

--- a/lonboard/experimental/layer_extension.py
+++ b/lonboard/experimental/layer_extension.py
@@ -8,28 +8,21 @@ class BrushingExtension(BaseExtension):
     """
     Adds GPU-based data brushing functionalities to layers. It allows the layer to
     show/hide objects based on the current pointer position.
-    """
 
-    _extension_type = traitlets.Unicode("brushing").tag(sync=True)
+    # Layer Properties
 
-    _layer_traits = {
-        "brushing_enabled": traitlets.Bool(True).tag(sync=True),
-        "brushing_target": traitlets.Unicode("source", allow_none=True).tag(sync=True),
-        "brushing_radius": traitlets.Float(allow_none=True, min=0).tag(sync=True),
-        # TODO: update trait
-        "get_brushing_target": traitlets.Any(allow_none=True).tag(sync=True),
-    }
+    This extension dynamically enables the following properties onto the layer(s) where
+    it is included:
 
-    # brushing_enabled = traitlets.Bool(True).tag(sync=True)
-    """
+    ## `brushing_enabled`
+
     Enable/disable brushing. If brushing is disabled, all objects are rendered.
 
     - Type: `bool`, optional
     - Default: `True`
-    """
 
-    # brushing_target = traitlets.Unicode("source", allow_none=True).tag(sync=True)
-    """
+    ## `brushing_target`
+
     The position used to filter each object by.
 
     - Type: `str`, optional
@@ -38,16 +31,27 @@ class BrushingExtension(BaseExtension):
 
     - Default: `10000`
 
-    """
+    ## `brushing_radius`
 
-    # brushing_radius = traitlets.Float(allow_none=True, min=0).tag(sync=True)
-    """
     The brushing radius centered at the pointer, in meters. If a data object is within
     this circle, it is rendered; otherwise it is hidden.
 
     - Type: `float`, optional
     - Default: `10000`
+
+    An example is in the [County-to-County Migration
+    notebook](https://developmentseed.org/lonboard/latest/examples/migration/).
     """
+
+    _extension_type = traitlets.Unicode("brushing").tag(sync=True)
+
+    _layer_traits = {
+        "brushing_enabled": traitlets.Bool(True).tag(sync=True),
+        "brushing_target": traitlets.Unicode("source", allow_none=True).tag(sync=True),
+        "brushing_radius": traitlets.Float(allow_none=True, min=0).tag(sync=True),
+        # TODO: Add trait and support
+        # "get_brushing_target": traitlets.Any(allow_none=True).tag(sync=True),
+    }
 
     # TODO: update trait
     # get_brushing_target = traitlets.Any(allow_none=True).tag(sync=True)
@@ -60,7 +64,40 @@ class BrushingExtension(BaseExtension):
 
 
 class CollisionFilterExtension(BaseExtension):
-    """Allows layers to hide overlapping objects."""
+    """Allows layers to hide overlapping objects.
+
+    # Layer Properties
+
+    This extension dynamically enables the following properties onto the layer(s) where
+    it is included:
+
+    ## `collision_enabled`
+
+    Enable/disable collisions. If collisions are disabled, all objects are rendered.
+
+    - Type: `bool`, optional
+    - Default: `True`
+
+    ## `collision_group`
+
+    Collision group this layer belongs to. If it is not set, the 'default' collision
+    group is used
+
+    - Type: `str`, optional
+    - Default: `None`
+
+    ## `get_collision_priority`
+
+    Accessor for collision priority. Must return a number in the range -1000 -> 1000.
+    Features with higher values are shown preferentially.
+
+    - Type: [FloatAccessor][lonboard.traits.FloatAccessor], optional
+        - If a number is provided, it is used as the priority for all objects.
+        - If an array is provided, each value in the array will be used as the priority
+          for the object at the same row index.
+    - Default: `0`.
+
+    """
 
     _extension_type = traitlets.Unicode("collision-filter").tag(sync=True)
 
@@ -70,50 +107,77 @@ class CollisionFilterExtension(BaseExtension):
         "get_collision_priority": FloatAccessor(allow_none=True),
     }
 
-    #   /**
-    #    * Props to override when rendering collision map
-    #    */
-    #   collisionTestProps?: {};
-
-    # collision_enabled = traitlets.Bool(True).tag(sync=True)
-    """Enable/disable collisions. If collisions are disabled, all objects are rendered.
-
-    - Type: `bool`, optional
-    - Default: `True`
-    """
-
-    # collision_group = traitlets.Unicode().tag(sync=True)
-    """
-    Collision group this layer belongs to. If it is not set, the 'default' collision
-    group is used
-
-    - Type: `string`, optional
-    - Default: `None`
-    """
-
-    # get_collision_priority = FloatAccessor(allow_none=True)
-    """
-    Accessor for collision priority. Must return a number in the range -1000 -> 1000.
-    Features with higher values are shown preferentially.
-
-    - Type: [FloatAccessor][lonboard.traits.FloatAccessor], optional
-        - If a number is provided, it is used as the priority for all objects.
-        - If an array is provided, each value in the array will be used as the priority
-          for the object at the same row index.
-    - Default: `0`.
-    """
-
 
 class DataFilterExtension(BaseExtension):
     """
     Adds GPU-based data filtering functionalities to layers. It allows the layer to
     show/hide objects based on user-defined properties.
 
-    ### Layer Parameters
+    # Example
 
+    ```py
+    from lonboard import Map, ScatterplotLayer
+    from lonboard.colormap import apply_continuous_cmap
+    from lonboard.experimental import DataFilterExtension
+
+    gdf = gpd.GeoDataFrame(...)
+    extension = DataFilterExtension()
+    layer = ScatterplotLayer.from_geopandas(
+        gdf,
+        extensions=[extension],
+        get_filter_value=gdf["filter_value"], # replace with desired column
+        filter_range=[0, 5] # replace with desired filter range
+    )
     ```
-    get_filter_value = FloatAccessor(None, allow_none=False)
-    ```
+
+    # Layer Properties
+
+    ## `filter_enabled`
+
+    Enable/disable the data filter. If the data filter is disabled, all objects are
+    rendered.
+
+    - Type: `bool`, optional
+    - Default: `True`
+
+    ## `filter_range`
+
+    The (min, max) bounds which defines whether an object should be rendered.
+
+    If an object's filtered value is within the bounds, the object will be rendered;
+    otherwise it will be hidden.
+
+    - Type: Tuple[float, float], optional
+    - Default: `(-1, 1)`
+
+    ## `filter_soft_range`
+
+    If specified, objects will be faded in/out instead of abruptly shown/hidden.
+
+    When the filtered value is outside of the bounds defined by `filter_soft_range` but
+    still within the bounds defined by `filter_range`, the object will be rendered as
+    "faded".
+
+    - Type: Tuple[float, float], optional
+    - Default: `None`
+
+    ## `filter_transform_size`
+
+    When an object is "faded", manipulate its size so that it appears smaller or
+    thinner. Only works if `filter_soft_range` is specified.
+
+    - Type: `bool`, optional
+    - Default: `True`
+
+    ## `filter_transform_color`
+
+    When an object is "faded", manipulate its opacity so that it appears more
+    translucent. Only works if `filter_soft_range` is specified.
+
+    - Type: `bool`, optional
+    - Default: `True`
+
+    ## `get_filter_value`
 
     Accessor to retrieve the value for each object that it will be filtered by.
 
@@ -149,57 +213,4 @@ class DataFilterExtension(BaseExtension):
 
     - Type: `int`, optional
     - Default 1.
-    """
-
-    # TODO: document in constructor and then remove.
-    # filter_enabled = traitlets.Bool(True).tag(sync=True)
-    """
-    Enable/disable the data filter. If the data filter is disabled, all objects are
-    rendered.
-
-    - Type: `bool`, optional
-    - Default: `True`
-    """
-
-    # filter_range = traitlets.Tuple(
-    #     traitlets.Float(), traitlets.Float(), default_value=(-1, 1)
-    # ).tag(sync=True)
-    """The (min, max) bounds which defines whether an object should be rendered.
-
-    If an object's filtered value is within the bounds, the object will be rendered;
-    otherwise it will be hidden.
-
-    - Type: Tuple[float, float], optional
-    - Default: `(-1, 1)`
-    """
-
-    # filter_soft_range = traitlets.Tuple(
-    #     traitlets.Float(), traitlets.Float(), default_value=None, allow_none=True
-    # ).tag(sync=True)
-    """If specified, objects will be faded in/out instead of abruptly shown/hidden.
-
-    When the filtered value is outside of the bounds defined by `filter_soft_range` but
-    still within the bounds defined by `filter_range`, the object will be rendered as
-    "faded".
-
-    - Type: Tuple[float, float], optional
-    - Default: `None`
-    """
-
-    # filter_transform_size = traitlets.Bool(True).tag(sync=True)
-    """
-    When an object is "faded", manipulate its size so that it appears smaller or
-    thinner. Only works if `filter_soft_range` is specified.
-
-    - Type: `bool`, optional
-    - Default: `True`
-    """
-
-    # filter_transform_color = traitlets.Bool(True).tag(sync=True)
-    """
-    When an object is "faded", manipulate its opacity so that it appears more
-    translucent. Only works if `filter_soft_range` is specified.
-
-    - Type: `bool`, optional
-    - Default: `True`
     """

--- a/lonboard/experimental/layer_extension.py
+++ b/lonboard/experimental/layer_extension.py
@@ -88,3 +88,74 @@ class CollisionFilterExtension(BaseExtension):
           for the object at the same row index.
     - Default: `0`.
     """
+
+
+class DataFilterExtension(BaseExtension):
+    """
+    Adds GPU-based data filtering functionalities to layers. It allows the layer to
+    show/hide objects based on user-defined properties.
+    """
+
+    _extension_type = traitlets.Unicode("data-filter").tag(sync=True)
+
+    # TODO: support filterSize > 1
+    get_filter_value = FloatAccessor(allow_none=False)
+    """Accessor to retrieve the value for each object that it will be filtered by.
+
+    - Type: [FloatAccessor][lonboard.traits.FloatAccessor]
+        - If a number is provided, it is used as the value for all objects.
+        - If an array is provided, each value in the array will be used as the value
+          for the object at the same row index.
+    """
+
+    filter_enabled = traitlets.Bool(True).tag(sync=True)
+    """
+    Enable/disable the data filter. If the data filter is disabled, all objects are
+    rendered.
+
+    - Type: `bool`, optional
+    - Default: `True`
+    """
+
+    filter_range = traitlets.Tuple(
+        traitlets.Float(), traitlets.Float(), default_value=(-1, 1)
+    ).tag(sync=True)
+    """The (min, max) bounds which defines whether an object should be rendered.
+
+    If an object's filtered value is within the bounds, the object will be rendered;
+    otherwise it will be hidden.
+
+    - Type: Tuple[float, float], optional
+    - Default: `(-1, 1)`
+    """
+
+    filter_soft_range = traitlets.Tuple(
+        traitlets.Float(), traitlets.Float(), default_value=None, allow_none=True
+    ).tag(sync=True)
+    """If specified, objects will be faded in/out instead of abruptly shown/hidden.
+
+    When the filtered value is outside of the bounds defined by `filter_soft_range` but
+    still within the bounds defined by `filter_range`, the object will be rendered as
+    "faded".
+
+    - Type: Tuple[float, float], optional
+    - Default: `None`
+    """
+
+    filter_transform_size = traitlets.Bool(True).tag(sync=True)
+    """
+    When an object is "faded", manipulate its size so that it appears smaller or
+    thinner. Only works if `filter_soft_range` is specified.
+
+    - Type: `bool`, optional
+    - Default: `True`
+    """
+
+    filter_transform_color = traitlets.Bool(True).tag(sync=True)
+    """
+    When an object is "faded", manipulate its opacity so that it appears more
+    translucent. Only works if `filter_soft_range` is specified.
+
+    - Type: `bool`, optional
+    - Default: `True`
+    """

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,7 +121,6 @@ plugins:
       canonical_version: "latest"
   - mkdocs-jupyter:
       include_source: True
-      include: ["examples/**/*.ipynb"]
       ignore: ["**/.ipynb_checkpoints/*.ipynb"]
   - mkdocstrings:
       enable_inventory: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,6 +121,7 @@ plugins:
       canonical_version: "latest"
   - mkdocs-jupyter:
       include_source: True
+      include: ["examples/**/*.ipynb"]
       ignore: ["**/.ipynb_checkpoints/*.ipynb"]
   - mkdocstrings:
       enable_inventory: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,19 +46,26 @@ nav:
       - api/colormap.md
       - api/traits.md
       - Experimental:
-        - Layer Extensions:
-          - api/layer-extensions/brushing-extension.md
-          - api/layer-extensions/collision-filter-extension.md
-        - Layers:
-          - api/layers/arc-layer.md
-          - api/layers/text-layer.md
-        - api/experimental/traits.md
+          - Layer Extensions:
+              - api/layer-extensions/index.md
+              - api/layer-extensions/brushing-extension.md
+              - api/layer-extensions/collision-filter-extension.md
+              - api/layer-extensions/data-filter-extension.md
+          - Layers:
+              - api/layers/arc-layer.md
+              - api/layers/text-layer.md
+          - api/experimental/traits.md
 
   # - Caveats: caveats.md
   - Performance: performance.md
   - Changelog: CHANGELOG.md
   - Alternatives: alternatives.md
   - "How it works?": how-it-works.md
+
+  # - Ecosystem:
+  #     - ecosystem/index.md
+  #     - ecosystem/geopandas.md
+  #     - ecosystem/geoarrow.md
 
 watch:
   - lonboard

--- a/src/model/base-layer.ts
+++ b/src/model/base-layer.ts
@@ -1,0 +1,128 @@
+// NOTE: the content of this file is isolated to avoid circular imports.
+
+import type {
+  Layer,
+  LayerExtension,
+  LayerProps,
+  PickingInfo,
+} from "@deck.gl/core/typed";
+import type { WidgetModel } from "@jupyter-widgets/base";
+import { loadChildModels } from "../util.js";
+import { initializeExtension } from "./extension.js";
+import type { BaseExtensionModel } from "./extension.js";
+import { BaseModel } from "./base.js";
+
+export abstract class BaseLayerModel extends BaseModel {
+  protected pickable: LayerProps["pickable"];
+  protected visible: LayerProps["visible"];
+  protected opacity: LayerProps["opacity"];
+  protected autoHighlight: LayerProps["autoHighlight"];
+
+  protected extensions: BaseExtensionModel[];
+
+  /** Names of additional layer properties that are dynamically added by
+   * extensions and should be rendered with layer attributes.
+   */
+  extensionLayerPropertyNames: string[] = [];
+
+  constructor(model: WidgetModel, updateStateCallback: () => void) {
+    super(model, updateStateCallback);
+
+    this.initRegularAttribute("pickable", "pickable");
+    this.initRegularAttribute("visible", "visible");
+    this.initRegularAttribute("opacity", "opacity");
+    this.initRegularAttribute("auto_highlight", "autoHighlight");
+
+    this.extensions = [];
+  }
+
+  async loadSubModels() {
+    await this.initLayerExtensions();
+  }
+
+  extensionInstances(): LayerExtension[] {
+    return this.extensions.map((extension) => extension.extensionInstance);
+  }
+
+  extensionProps() {
+    let props: Record<string, any> = {};
+    for (const layerPropertyName of this.extensionLayerPropertyNames) {
+      if (this[layerPropertyName as keyof this] !== undefined) {
+        props[layerPropertyName] = this[layerPropertyName as keyof this];
+      }
+    }
+    return props;
+  }
+
+  onClick(pickingInfo: PickingInfo) {
+    if (!pickingInfo.index) return;
+
+    this.model.set("selected_index", pickingInfo.index);
+    this.model.save_changes();
+  }
+
+  baseLayerProps(): LayerProps {
+    // console.log("extensions", this.extensionInstances());
+    // console.log("extensionprops", this.extensionProps());
+    return {
+      extensions: this.extensionInstances(),
+      ...this.extensionProps(),
+      id: this.model.model_id,
+      pickable: this.pickable,
+      visible: this.visible,
+      opacity: this.opacity,
+      autoHighlight: this.autoHighlight,
+      onClick: this.onClick.bind(this),
+    };
+  }
+
+  /**
+   * Layer properties for this layer
+   */
+  abstract layerProps(): Omit<LayerProps, "id">;
+
+  /**
+   * Generate a deck.gl layer from this model description.
+   */
+  abstract render(): Layer;
+
+  // NOTE: this is flaky, especially when changing extensions
+  // This is the main place where extensions should still be considered
+  // experimental
+  async initLayerExtensions() {
+    const initExtensionsCallback = async () => {
+      console.log("initExtensionsCallback");
+      const childModelIds = this.model.get("extensions");
+      if (!childModelIds) {
+        this.extensions = [];
+        return;
+      }
+
+      console.log(childModelIds);
+      const childModels = await loadChildModels(
+        this.model.widget_manager,
+        childModelIds,
+      );
+
+      const extensions: BaseExtensionModel[] = [];
+      for (const childModel of childModels) {
+        const extension = await initializeExtension(
+          childModel,
+          this,
+          this.updateStateCallback,
+        );
+        extensions.push(extension);
+      }
+
+      this.extensions = extensions;
+    };
+    await initExtensionsCallback();
+
+    // Remove all existing change callbacks for this attribute
+    this.model.off(`change:extensions`);
+
+    this.model.on(`change:extensions`, initExtensionsCallback);
+
+    this.callbacks.set(`change:extensions`, initExtensionsCallback);
+  }
+}

--- a/src/model/base.ts
+++ b/src/model/base.ts
@@ -1,5 +1,13 @@
-import type { WidgetModel } from "@jupyter-widgets/base";
 import { parseAccessor } from "../accessor.js";
+import type {
+  Layer,
+  LayerExtension,
+  LayerProps,
+  PickingInfo,
+} from "@deck.gl/core/typed";
+import type { WidgetModel } from "@jupyter-widgets/base";
+import { loadChildModels } from "../util.js";
+import { BaseExtensionModel, initializeExtension } from "./extension.js";
 
 export abstract class BaseModel {
   protected model: WidgetModel;
@@ -28,7 +36,7 @@ export abstract class BaseModel {
    * @param   {string}  pythonName  Name of attribute on Python model (usually snake-cased)
    * @param   {string}  jsName      Name of attribute in deck.gl (usually camel-cased)
    */
-  protected initRegularAttribute(pythonName: string, jsName: string) {
+  initRegularAttribute(pythonName: string, jsName: string) {
     this[jsName as keyof this] = this.model.get(pythonName);
 
     // Remove all existing change callbacks for this attribute
@@ -52,7 +60,7 @@ export abstract class BaseModel {
    * @param   {string}  pythonName  Name of attribute on Python model (usually snake-cased)
    * @param   {string}  jsName      Name of attribute in deck.gl (usually camel-cased)
    */
-  protected initVectorizedAccessor(pythonName: string, jsName: string) {
+  initVectorizedAccessor(pythonName: string, jsName: string) {
     this[jsName as keyof this] = parseAccessor(this.model.get(pythonName));
 
     // Remove all existing change callbacks for this attribute
@@ -73,5 +81,120 @@ export abstract class BaseModel {
     for (const [changeKey, callback] of Object.entries(this.callbacks)) {
       this.model.off(changeKey, callback);
     }
+  }
+}
+
+export abstract class BaseLayerModel extends BaseModel {
+  protected pickable: LayerProps["pickable"];
+  protected visible: LayerProps["visible"];
+  protected opacity: LayerProps["opacity"];
+  protected autoHighlight: LayerProps["autoHighlight"];
+
+  protected extensions: BaseExtensionModel[];
+
+  /** Names of additional layer properties that are dynamically added by
+   * extensions and should be rendered with layer attributes.
+   */
+  extensionLayerPropertyNames: string[] = [];
+
+  constructor(model: WidgetModel, updateStateCallback: () => void) {
+    super(model, updateStateCallback);
+
+    this.initRegularAttribute("pickable", "pickable");
+    this.initRegularAttribute("visible", "visible");
+    this.initRegularAttribute("opacity", "opacity");
+    this.initRegularAttribute("auto_highlight", "autoHighlight");
+
+    this.extensions = [];
+  }
+
+  async loadSubModels() {
+    await this.initLayerExtensions();
+  }
+
+  extensionInstances(): LayerExtension[] {
+    return this.extensions.map((extension) => extension.extensionInstance);
+  }
+
+  extensionProps() {
+    let props: Record<string, any> = {};
+    for (const layerPropertyName of this.extensionLayerPropertyNames) {
+      if (this[layerPropertyName as keyof this] !== undefined) {
+        props[layerPropertyName] = this[layerPropertyName as keyof this];
+      }
+    }
+    return props;
+  }
+
+  onClick(pickingInfo: PickingInfo) {
+    if (!pickingInfo.index) return;
+
+    this.model.set("selected_index", pickingInfo.index);
+    this.model.save_changes();
+  }
+
+  baseLayerProps(): LayerProps {
+    // console.log("extensions", this.extensionInstances());
+    // console.log("extensionprops", this.extensionProps());
+    return {
+      extensions: this.extensionInstances(),
+      ...this.extensionProps(),
+      id: this.model.model_id,
+      pickable: this.pickable,
+      visible: this.visible,
+      opacity: this.opacity,
+      autoHighlight: this.autoHighlight,
+      onClick: this.onClick.bind(this),
+    };
+  }
+
+  /**
+   * Layer properties for this layer
+   */
+  abstract layerProps(): Omit<LayerProps, "id">;
+
+  /**
+   * Generate a deck.gl layer from this model description.
+   */
+  abstract render(): Layer;
+
+  // NOTE: this is flaky, especially when changing extensions
+  // This is the main place where extensions should still be considered
+  // experimental
+  async initLayerExtensions() {
+    const initExtensionsCallback = async () => {
+      console.log("initExtensionsCallback");
+      const childModelIds = this.model.get("extensions");
+      if (!childModelIds) {
+        this.extensions = [];
+        return;
+      }
+
+      console.log(childModelIds);
+      const childModels = await loadChildModels(
+        this.model.widget_manager,
+        childModelIds,
+      );
+
+      const extensions: BaseExtensionModel[] = [];
+      for (const childModel of childModels) {
+        const extension = await initializeExtension(
+          childModel,
+          this,
+          this.updateStateCallback,
+        );
+        extensions.push(extension);
+      }
+
+      this.extensions = extensions;
+    };
+    await initExtensionsCallback();
+
+    // Remove all existing change callbacks for this attribute
+    this.model.off(`change:extensions`);
+
+    this.model.on(`change:extensions`, initExtensionsCallback);
+
+    this.callbacks.set(`change:extensions`, initExtensionsCallback);
   }
 }

--- a/src/model/base.ts
+++ b/src/model/base.ts
@@ -1,13 +1,7 @@
+// NOTE: the content of this file is isolated to avoid circular imports.
+
 import { parseAccessor } from "../accessor.js";
-import type {
-  Layer,
-  LayerExtension,
-  LayerProps,
-  PickingInfo,
-} from "@deck.gl/core/typed";
 import type { WidgetModel } from "@jupyter-widgets/base";
-import { loadChildModels } from "../util.js";
-import { BaseExtensionModel, initializeExtension } from "./extension.js";
 
 export abstract class BaseModel {
   protected model: WidgetModel;
@@ -81,120 +75,5 @@ export abstract class BaseModel {
     for (const [changeKey, callback] of Object.entries(this.callbacks)) {
       this.model.off(changeKey, callback);
     }
-  }
-}
-
-export abstract class BaseLayerModel extends BaseModel {
-  protected pickable: LayerProps["pickable"];
-  protected visible: LayerProps["visible"];
-  protected opacity: LayerProps["opacity"];
-  protected autoHighlight: LayerProps["autoHighlight"];
-
-  protected extensions: BaseExtensionModel[];
-
-  /** Names of additional layer properties that are dynamically added by
-   * extensions and should be rendered with layer attributes.
-   */
-  extensionLayerPropertyNames: string[] = [];
-
-  constructor(model: WidgetModel, updateStateCallback: () => void) {
-    super(model, updateStateCallback);
-
-    this.initRegularAttribute("pickable", "pickable");
-    this.initRegularAttribute("visible", "visible");
-    this.initRegularAttribute("opacity", "opacity");
-    this.initRegularAttribute("auto_highlight", "autoHighlight");
-
-    this.extensions = [];
-  }
-
-  async loadSubModels() {
-    await this.initLayerExtensions();
-  }
-
-  extensionInstances(): LayerExtension[] {
-    return this.extensions.map((extension) => extension.extensionInstance);
-  }
-
-  extensionProps() {
-    let props: Record<string, any> = {};
-    for (const layerPropertyName of this.extensionLayerPropertyNames) {
-      if (this[layerPropertyName as keyof this] !== undefined) {
-        props[layerPropertyName] = this[layerPropertyName as keyof this];
-      }
-    }
-    return props;
-  }
-
-  onClick(pickingInfo: PickingInfo) {
-    if (!pickingInfo.index) return;
-
-    this.model.set("selected_index", pickingInfo.index);
-    this.model.save_changes();
-  }
-
-  baseLayerProps(): LayerProps {
-    // console.log("extensions", this.extensionInstances());
-    // console.log("extensionprops", this.extensionProps());
-    return {
-      extensions: this.extensionInstances(),
-      ...this.extensionProps(),
-      id: this.model.model_id,
-      pickable: this.pickable,
-      visible: this.visible,
-      opacity: this.opacity,
-      autoHighlight: this.autoHighlight,
-      onClick: this.onClick.bind(this),
-    };
-  }
-
-  /**
-   * Layer properties for this layer
-   */
-  abstract layerProps(): Omit<LayerProps, "id">;
-
-  /**
-   * Generate a deck.gl layer from this model description.
-   */
-  abstract render(): Layer;
-
-  // NOTE: this is flaky, especially when changing extensions
-  // This is the main place where extensions should still be considered
-  // experimental
-  async initLayerExtensions() {
-    const initExtensionsCallback = async () => {
-      console.log("initExtensionsCallback");
-      const childModelIds = this.model.get("extensions");
-      if (!childModelIds) {
-        this.extensions = [];
-        return;
-      }
-
-      console.log(childModelIds);
-      const childModels = await loadChildModels(
-        this.model.widget_manager,
-        childModelIds,
-      );
-
-      const extensions: BaseExtensionModel[] = [];
-      for (const childModel of childModels) {
-        const extension = await initializeExtension(
-          childModel,
-          this,
-          this.updateStateCallback,
-        );
-        extensions.push(extension);
-      }
-
-      this.extensions = extensions;
-    };
-    await initExtensionsCallback();
-
-    // Remove all existing change callbacks for this attribute
-    this.model.off(`change:extensions`);
-
-    this.model.on(`change:extensions`, initExtensionsCallback);
-
-    this.callbacks.set(`change:extensions`, initExtensionsCallback);
   }
 }

--- a/src/model/extension.ts
+++ b/src/model/extension.ts
@@ -8,7 +8,7 @@ import {
   DataFilterExtension as _DataFilterExtension,
 } from "@deck.gl/extensions/typed";
 import type { WidgetModel } from "@jupyter-widgets/base";
-import { BaseModel } from "./base.js";
+import { BaseModel, BaseLayerModel } from "./base.js";
 
 export abstract class BaseExtensionModel extends BaseModel {
   static extensionType: string;
@@ -18,8 +18,6 @@ export abstract class BaseExtensionModel extends BaseModel {
   constructor(model: WidgetModel, updateStateCallback: () => void) {
     super(model, updateStateCallback);
   }
-
-  abstract extensionProps(): {};
 }
 
 export class BrushingExtension extends BaseExtensionModel {
@@ -32,27 +30,32 @@ export class BrushingExtension extends BaseExtensionModel {
   protected brushingTarget?: BrushingExtensionProps["brushingTarget"];
   protected brushingRadius?: BrushingExtensionProps["brushingRadius"];
 
-  constructor(model: WidgetModel, updateStateCallback: () => void) {
+  constructor(
+    model: WidgetModel,
+    layerModel: BaseLayerModel,
+    updateStateCallback: () => void,
+  ) {
     super(model, updateStateCallback);
     this.extensionInstance = new _BrushingExtension();
 
-    this.initRegularAttribute("brushing_enabled", "brushingEnabled");
-    this.initRegularAttribute("brushing_target", "brushingTarget");
-    this.initRegularAttribute("brushing_radius", "brushingRadius");
+    layerModel.initRegularAttribute("brushing_enabled", "brushingEnabled");
+    layerModel.initRegularAttribute("brushing_target", "brushingTarget");
+    layerModel.initRegularAttribute("brushing_radius", "brushingRadius");
 
-    this.initVectorizedAccessor("get_brushing_target", "getBrushingTarget");
-  }
+    layerModel.initVectorizedAccessor(
+      "get_brushing_target",
+      "getBrushingTarget",
+    );
 
-  extensionProps(): BrushingExtensionProps {
-    // TODO: vectorized accessor array doesn't get set yet on data.attributes
-    return {
-      ...(this.getBrushingTarget && {
-        getBrushingTarget: this.getBrushingTarget,
-      }),
-      ...(this.brushingEnabled && { brushingEnabled: this.brushingEnabled }),
-      ...(this.brushingTarget && { brushingTarget: this.brushingTarget }),
-      ...(this.brushingRadius && { brushingRadius: this.brushingRadius }),
-    };
+    // Update the layer model with the list of the JS property names added by
+    // this extension
+    layerModel.extensionLayerPropertyNames = [
+      ...layerModel.extensionLayerPropertyNames,
+      "brushingEnabled",
+      "brushingTarget",
+      "brushingRadius",
+      "getBrushingTarget",
+    ];
   }
 }
 
@@ -66,32 +69,35 @@ export class CollisionFilterExtension extends BaseExtensionModel {
   protected collisionTestProps?: CollisionFilterExtensionProps["collisionTestProps"];
   protected getCollisionPriority?: CollisionFilterExtensionProps["getCollisionPriority"];
 
-  constructor(model: WidgetModel, updateStateCallback: () => void) {
+  constructor(
+    model: WidgetModel,
+    layerModel: BaseLayerModel,
+    updateStateCallback: () => void,
+  ) {
     super(model, updateStateCallback);
     this.extensionInstance = new _CollisionFilterExtension();
 
-    this.initRegularAttribute("collision_enabled", "collisionEnabled");
-    this.initRegularAttribute("collision_group", "collisionGroup");
-    this.initRegularAttribute("collision_test_props", "collisionTestProps");
+    layerModel.initRegularAttribute("collision_enabled", "collisionEnabled");
+    layerModel.initRegularAttribute("collision_group", "collisionGroup");
+    layerModel.initRegularAttribute(
+      "collision_test_props",
+      "collisionTestProps",
+    );
 
-    this.initVectorizedAccessor(
+    layerModel.initVectorizedAccessor(
       "get_collision_priority",
       "getCollisionPriority",
     );
-  }
 
-  extensionProps(): CollisionFilterExtensionProps {
-    // @ts-expect-error
-    return {
-      ...(this.collisionEnabled !== undefined && { collisionEnabled: this.collisionEnabled }),
-      ...(this.collisionGroup && { collisionGroup: this.collisionGroup }),
-      ...(this.collisionTestProps && {
-        collisionTestProps: this.collisionTestProps,
-      }),
-      ...(this.getCollisionPriority && {
-        getCollisionPriority: this.getCollisionPriority,
-      }),
-    };
+    // Update the layer model with the list of the JS property names added by
+    // this extension
+    layerModel.extensionLayerPropertyNames = [
+      ...layerModel.extensionLayerPropertyNames,
+      "collisionEnabled",
+      "collisionGroup",
+      "collisionTestProps",
+      "getCollisionPriority",
+    ];
   }
 }
 
@@ -108,53 +114,74 @@ export class DataFilterExtension extends BaseExtensionModel {
   protected filterTransformSize?: DataFilterExtensionProps["filterTransformSize"];
   protected filterTransformColor?: DataFilterExtensionProps["filterTransformColor"];
 
-  constructor(model: WidgetModel, updateStateCallback: () => void) {
+  constructor(
+    model: WidgetModel,
+    layerModel: BaseLayerModel,
+    updateStateCallback: () => void,
+  ) {
     super(model, updateStateCallback);
     // TODO: set filterSize, fp64, countItems in constructor
     this.extensionInstance = new _DataFilterExtension();
 
-    this.initRegularAttribute("filter_enabled", "filterEnabled");
-    this.initRegularAttribute("filter_range", "filterRange");
-    this.initRegularAttribute("filter_soft_range", "filterSoftRange");
-    this.initRegularAttribute("filter_transform_size", "filterTransformSize");
-    this.initRegularAttribute("filter_transform_color", "filterTransformColor");
+    // Properties added by the extension onto the layer
+    layerModel.initRegularAttribute("filter_enabled", "filterEnabled");
+    layerModel.initRegularAttribute("filter_range", "filterRange");
+    layerModel.initRegularAttribute("filter_soft_range", "filterSoftRange");
+    layerModel.initRegularAttribute(
+      "filter_transform_size",
+      "filterTransformSize",
+    );
+    layerModel.initRegularAttribute(
+      "filter_transform_color",
+      "filterTransformColor",
+    );
 
-    this.initVectorizedAccessor("get_filter_value", "getFilterValue");
-  }
+    layerModel.initVectorizedAccessor("get_filter_value", "getFilterValue");
 
-  extensionProps(): DataFilterExtensionProps {
-    return {
-      ...(this.getFilterValue && { getFilterValue: this.getFilterValue }),
-      ...(this.filterEnabled && { filterEnabled: this.filterEnabled }),
-      ...(this.filterRange && { filterRange: this.filterRange }),
-      ...(this.filterSoftRange && { filterSoftRange: this.filterSoftRange }),
-      ...(this.filterTransformSize && {
-        filterTransformSize: this.filterTransformSize,
-      }),
-      ...(this.filterTransformColor && {
-        filterTransformColor: this.filterTransformColor,
-      }),
-    };
+    // Update the layer model with the list of the JS property names added by
+    // this extension
+    layerModel.extensionLayerPropertyNames = [
+      ...layerModel.extensionLayerPropertyNames,
+      "filterEnabled",
+      "filterRange",
+      "filterSoftRange",
+      "filterTransformSize",
+      "filterTransformColor",
+      "getFilterValue",
+    ];
   }
 }
 
 export async function initializeExtension(
   model: WidgetModel,
+  layerModel: BaseLayerModel,
   updateStateCallback: () => void,
 ): Promise<BaseExtensionModel> {
   const extensionType = model.get("_extension_type");
   let extensionModel: BaseExtensionModel;
   switch (extensionType) {
     case BrushingExtension.extensionType:
-      extensionModel = new BrushingExtension(model, updateStateCallback);
+      extensionModel = new BrushingExtension(
+        model,
+        layerModel,
+        updateStateCallback,
+      );
       break;
 
     case CollisionFilterExtension.extensionType:
-      extensionModel = new CollisionFilterExtension(model, updateStateCallback);
+      extensionModel = new CollisionFilterExtension(
+        model,
+        layerModel,
+        updateStateCallback,
+      );
       break;
 
     case DataFilterExtension.extensionType:
-      extensionModel = new DataFilterExtension(model, updateStateCallback);
+      extensionModel = new DataFilterExtension(
+        model,
+        layerModel,
+        updateStateCallback,
+      );
       break;
 
     default:

--- a/src/model/extension.ts
+++ b/src/model/extension.ts
@@ -8,7 +8,8 @@ import {
   DataFilterExtension as _DataFilterExtension,
 } from "@deck.gl/extensions/typed";
 import type { WidgetModel } from "@jupyter-widgets/base";
-import { BaseModel, BaseLayerModel } from "./base.js";
+import { BaseModel } from "./base.js";
+import type { BaseLayerModel } from "./base-layer.js";
 
 export abstract class BaseExtensionModel extends BaseModel {
   static extensionType: string;

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -1,6 +1,6 @@
 export { BaseModel } from "./base.js";
+export { BaseLayerModel } from "./base-layer.js";
 export {
-  BaseLayerModel,
   PathModel,
   ScatterplotModel,
   SolidPolygonModel,

--- a/src/model/layer.ts
+++ b/src/model/layer.ts
@@ -38,6 +38,11 @@ export abstract class BaseLayerModel extends BaseModel {
 
   protected extensions: BaseExtensionModel[];
 
+  /** Names of additional layer properties that are dynamically added by
+   * extensions and should be rendered with layer attributes.
+   */
+  extensionLayerPropertyNames: string[] = [];
+
   constructor(model: WidgetModel, updateStateCallback: () => void) {
     super(model, updateStateCallback);
 
@@ -58,9 +63,11 @@ export abstract class BaseLayerModel extends BaseModel {
   }
 
   extensionProps() {
-    let props = {};
-    for (const extension of this.extensions) {
-      props = { ...props, ...extension.extensionProps() };
+    let props: Record<string, any> = {};
+    for (const layerPropertyName of this.extensionLayerPropertyNames) {
+      if (this[layerPropertyName as keyof this] !== undefined) {
+        props[layerPropertyName] = this[layerPropertyName as keyof this];
+      }
     }
     return props;
   }
@@ -119,6 +126,7 @@ export abstract class BaseLayerModel extends BaseModel {
       for (const childModel of childModels) {
         const extension = await initializeExtension(
           childModel,
+          this,
           this.updateStateCallback,
         );
         extensions.push(extension);

--- a/src/model/layer.ts
+++ b/src/model/layer.ts
@@ -1,10 +1,3 @@
-import type {
-  Layer,
-  LayerExtension,
-  LayerProps,
-  PickingInfo,
-  Texture,
-} from "@deck.gl/core/typed";
 import {
   GeoArrowArcLayer,
   GeoArrowArcLayerProps,
@@ -24,126 +17,9 @@ import {
 import type { WidgetModel } from "@jupyter-widgets/base";
 import * as arrow from "apache-arrow";
 import { parseParquetBuffers } from "../parquet.js";
-import { loadChildModels } from "../util.js";
-import { BaseModel } from "./base.js";
-import { BaseExtensionModel, initializeExtension } from "./extension.js";
+import { BaseLayerModel } from "./base.js";
 import { BitmapLayer, BitmapLayerProps } from "@deck.gl/layers/typed";
 import { TileLayer, TileLayerProps } from "@deck.gl/geo-layers/typed";
-
-export abstract class BaseLayerModel extends BaseModel {
-  protected pickable: LayerProps["pickable"];
-  protected visible: LayerProps["visible"];
-  protected opacity: LayerProps["opacity"];
-  protected autoHighlight: LayerProps["autoHighlight"];
-
-  protected extensions: BaseExtensionModel[];
-
-  /** Names of additional layer properties that are dynamically added by
-   * extensions and should be rendered with layer attributes.
-   */
-  extensionLayerPropertyNames: string[] = [];
-
-  constructor(model: WidgetModel, updateStateCallback: () => void) {
-    super(model, updateStateCallback);
-
-    this.initRegularAttribute("pickable", "pickable");
-    this.initRegularAttribute("visible", "visible");
-    this.initRegularAttribute("opacity", "opacity");
-    this.initRegularAttribute("auto_highlight", "autoHighlight");
-
-    this.extensions = [];
-  }
-
-  async loadSubModels() {
-    await this.initLayerExtensions();
-  }
-
-  extensionInstances(): LayerExtension[] {
-    return this.extensions.map((extension) => extension.extensionInstance);
-  }
-
-  extensionProps() {
-    let props: Record<string, any> = {};
-    for (const layerPropertyName of this.extensionLayerPropertyNames) {
-      if (this[layerPropertyName as keyof this] !== undefined) {
-        props[layerPropertyName] = this[layerPropertyName as keyof this];
-      }
-    }
-    return props;
-  }
-
-  onClick(pickingInfo: PickingInfo) {
-    if (!pickingInfo.index) return;
-
-    this.model.set("selected_index", pickingInfo.index);
-    this.model.save_changes();
-  }
-
-  baseLayerProps(): LayerProps {
-    // console.log("extensions", this.extensionInstances());
-    // console.log("extensionprops", this.extensionProps());
-    return {
-      extensions: this.extensionInstances(),
-      ...this.extensionProps(),
-      id: this.model.model_id,
-      pickable: this.pickable,
-      visible: this.visible,
-      opacity: this.opacity,
-      autoHighlight: this.autoHighlight,
-      onClick: this.onClick.bind(this),
-    };
-  }
-
-  /**
-   * Layer properties for this layer
-   */
-  abstract layerProps(): Omit<LayerProps, "id">;
-
-  /**
-   * Generate a deck.gl layer from this model description.
-   */
-  abstract render(): Layer;
-
-  // NOTE: this is flaky, especially when changing extensions
-  // This is the main place where extensions should still be considered
-  // experimental
-  async initLayerExtensions() {
-    const initExtensionsCallback = async () => {
-      console.log("initExtensionsCallback");
-      const childModelIds = this.model.get("extensions");
-      if (!childModelIds) {
-        this.extensions = [];
-        return;
-      }
-
-      console.log(childModelIds);
-      const childModels = await loadChildModels(
-        this.model.widget_manager,
-        childModelIds,
-      );
-
-      const extensions: BaseExtensionModel[] = [];
-      for (const childModel of childModels) {
-        const extension = await initializeExtension(
-          childModel,
-          this,
-          this.updateStateCallback,
-        );
-        extensions.push(extension);
-      }
-
-      this.extensions = extensions;
-    };
-    await initExtensionsCallback();
-
-    // Remove all existing change callbacks for this attribute
-    this.model.off(`change:extensions`);
-
-    this.model.on(`change:extensions`, initExtensionsCallback);
-
-    this.callbacks.set(`change:extensions`, initExtensionsCallback);
-  }
-}
 
 /**
  * An abstract base class for a layer that uses an Arrow Table as the data prop.

--- a/src/model/layer.ts
+++ b/src/model/layer.ts
@@ -17,7 +17,7 @@ import {
 import type { WidgetModel } from "@jupyter-widgets/base";
 import * as arrow from "apache-arrow";
 import { parseParquetBuffers } from "../parquet.js";
-import { BaseLayerModel } from "./base.js";
+import { BaseLayerModel } from "./base-layer.js";
 import { BitmapLayer, BitmapLayerProps } from "@deck.gl/layers/typed";
 import { TileLayer, TileLayerProps } from "@deck.gl/geo-layers/typed";
 


### PR DESCRIPTION
Connects to the deck.gl data filter extension ([example](https://deck.gl/examples/data-filter-extension), [docs](https://deck.gl/docs/api-reference/extensions/data-filter-extension)) for easy gpu-based data filtering.