### PR TITLE
Set map's parent display to flex

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -118,9 +118,10 @@ function App() {
 
       // Check if the height is not already set
       if (!parentStyle.height || parentStyle.height === "0px") {
-        // Set the height to 100% and min-height
+        // Set the height to 100%, min-height, and display to flex
         mapContainerParent.style.height = "100%";
         mapContainerParent.style.minHeight = "500px";
+        mapContainerParent.style.display = 'flex';
       }
     }
   }, []);


### PR DESCRIPTION
## What I am changing
Fixing the default height problem 


## How I did it
Main factor here is setting the map's the parent's div's display to flex.

The default `display:block` will try to cover the entire the contents if set to 100% but since at initializing there is no contents/canvas/children for the parent this would be 0px. While `display:flex` bypasses this.  

Another common solution for web app is to set the height and width to `100vh` and `100vw` but this assumes that the map will cover the entire viewport/iframe/window which might not work for jupyter widgets, sidepanels.

## How you can test it
Export a map using the following code:

```python
import geopandas as gpd
from lonboard import viz
gdf = gpd.read_parquet(...) # any file would do
map = viz(gdf)
map.to_html("test.html")
```

Before: 
<img width="1708" alt="Screenshot 2023-12-02 at 6 14 33 PM" src="https://github.com/developmentseed/lonboard/assets/30991698/d7db4a96-3332-4f33-ac35-7ba06feeb811">

After:
<img width="1709" alt="Screenshot 2023-12-02 at 6 13 37 PM" src="https://github.com/developmentseed/lonboard/assets/30991698/b3463c80-1e31-42e7-9407-d939f84afe23">

Let me know if you have other suggestions on how to tests this! 

## Related Issues
Related to #247
