### PR TITLE
Add font to index.css

### DIFF
--- a/src/tooltip/index.css
+++ b/src/tooltip/index.css
@@ -1,4 +1,9 @@
 /* Remove spaces between table cells */
+.lonboard-tooltip {
+  font-family: var(--jp-ui-font-family);
+  font-size: var(--jp-ui-font-size1);
+}
+
 .lonboard-tooltip table {
   border-collapse: collapse;
 }


### PR DESCRIPTION
## What I am changing
Add missing css to lonboard table

## How I did it
The problem is that when inside a jupyter notebook, the tooltip (and other html elements) inherit the some css from jupyter lab/notebook compared to running it in exported form. In this cases, it was the font. 

Here is the css of the tooltip when in jupyter lab. The one declaring the font is not related to the css of lonboard but the css of the body.
<img width="351" alt="Screenshot 2023-12-02 at 8 25 56 PM" src="https://github.com/developmentseed/lonboard/assets/30991698/549ef00a-a978-42a0-abe6-dcca883c51a6">

vs css of the tooltip when exported
<img width="255" alt="Screenshot 2023-12-02 at 8 30 27 PM" src="https://github.com/developmentseed/lonboard/assets/30991698/dff7f3aa-bd93-440e-80fd-8c0b9ca76126">

To fix this I added the missing font to the lonboard css. 

## How you can test it
Export map
```python
import geopandas as gpd
from lonboard import viz

gdf = gpd.read_parquet(...) # any file will do
map = viz(gdf)
map.to_html("test.html")
```


Before 
<img width="600" alt="Screenshot 2023-12-02 at 8 33 22 PM" src="https://github.com/developmentseed/lonboard/assets/30991698/53af07e0-32e4-4fc6-81b7-5b905e29631b">

After
<img width="573" alt="Screenshot 2023-12-02 at 8 34 02 PM" src="https://github.com/developmentseed/lonboard/assets/30991698/750042e2-feaa-4000-a424-3a94a62836a2">



## Related Issues
#248 
