### PR TITLE
[WIP] Bitmap and Bitmap Tile Layers

### DIFF
--- a/lonboard/_layer.py
+++ b/lonboard/_layer.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING
 import geopandas as gpd
 import ipywidgets
 import pyarrow as pa
-from shapely.geometry import box
 import traitlets
+from shapely.geometry import box
 
 from lonboard._base import BaseExtension, BaseWidget
 from lonboard._constants import EPSG_4326, EXTENSION_NAME, OGC_84

--- a/lonboard/_layer.py
+++ b/lonboard/_layer.py
@@ -722,3 +722,10 @@ class BitmapLayer(BaseLayer):
         gdf = gpd.GeoDataFrame(geometry=[box(*self.bounds)])
         table = geopandas_to_geoarrow(gdf)
         return table
+
+
+class BitmapTileLayer(BaseLayer):
+    _layer_type = traitlets.Unicode("bitmap_tile").tag(sync=True)
+    table = None
+
+    data = traitlets.Unicode(allow_none=True).tag(sync=True)

--- a/lonboard/_layer.py
+++ b/lonboard/_layer.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import geopandas as gpd
 import ipywidgets
 import pyarrow as pa
+from shapely.geometry import box
 import traitlets
 
 from lonboard._base import BaseExtension, BaseWidget
@@ -703,3 +704,21 @@ class HeatmapLayer(BaseLayer):
                 raise traitlets.TraitError("accessor must have same length as table")
 
         return proposal["value"]
+
+
+class BitmapLayer(BaseLayer):
+    _layer_type = traitlets.Unicode("bitmap").tag(sync=True)
+    # set table not required
+    # table = None
+    bounds = traitlets.List(
+        traitlets.Float(), default_value=None, allow_none=True, minlen=4, maxlen=4
+    ).tag(sync=True)
+
+    image = traitlets.Unicode(allow_none=True).tag(sync=True)
+
+    # hack to get initial view state to consider bounds/image
+    @property
+    def table(self):
+        gdf = gpd.GeoDataFrame(geometry=[box(*self.bounds)])
+        table = geopandas_to_geoarrow(gdf)
+        return table


### PR DESCRIPTION
Addresses #206 
Example usage:
```python
import geopandas as gpd
from lonboard import Map
from lonboard._layer import  BitmapLayer, BitmapTileLayer


layer = BitmapLayer(bounds=[-122.5190, 37.7045, -122.355, 37.829],image='https://raw.githubusercontent.com/visgl/deck.gl-data/master/website/sf-districts.png')
map_ = Map(layers=[layer])
map_
```
<img width="1298" alt="Screenshot 2023-12-03 at 5 23 37 AM" src="https://github.com/developmentseed/lonboard/assets/30991698/0a06df11-a198-4651-ba20-ab59e076ebbb">


and 
```python
layer = BitmapTileLayer(data='https://c.tile.openstreetmap.org/{z}/{x}/{y}.png')
map_ = Map(layers=[layer], _initial_view_state={'longitude': -122.42060000000001, 'latitude': 37.7543, 'zoom': 11})
map_
```

<img width="1296" alt="Screenshot 2023-12-03 at 5 23 26 AM" src="https://github.com/developmentseed/lonboard/assets/30991698/0064de71-3e75-4ed1-b717-fcd14df1be5a">

Decision Points
1. Best way to handle non arrow layers. Should we have new classes for non arrow layers that dont include fields like `table` or should we be extending existing classes and setting table to `null`/`None`
 2. What parameters should we include for both layers?
    
  