### PR TITLE
Fix displaying tooltip for first row

### DIFF
--- a/src/tooltip/index.ts
+++ b/src/tooltip/index.ts
@@ -31,7 +31,8 @@ export function getTooltip({ object }: GeoArrowPickingInfo): TooltipContent {
     // Without this block, we end up showing a tooltip even when not hovering
     // over a point
     if (
-      !object[rowIndexSymbol] ||
+      object[rowIndexSymbol] === null ||
+      object[rowIndexSymbol] === undefined ||
       (object[rowIndexSymbol] && object[rowIndexSymbol] < 0)
     ) {
       return null;


### PR DESCRIPTION
Previously, the falsy check didn't display a tooltip for the first row, where the `Symbol.for("rowIndex")` was 0.