### PR TITLE
Check epsg:4326 bounds in layer creation

### DIFF
--- a/lonboard/_layer.py
+++ b/lonboard/_layer.py
@@ -131,14 +131,14 @@ def default_geoarrow_viewport(
     # epsg:4326 bounds
     if table_centroid.num_items > 0:
         if table_centroid.x is not None and (
-            table_centroid.x < 180 or table_centroid.x > 180
+            table_centroid.x < -180 or table_centroid.x > 180
         ):
             msg = "Longitude of data's center is outside of WGS84 bounds.\n"
             msg += "Is data in WGS84 projection?"
             raise ValueError(msg)
 
         if table_centroid.y is not None and (
-            table_centroid.y < 90 or table_centroid.y > 90
+            table_centroid.y < -90 or table_centroid.y > 90
         ):
             msg = "Latitude of data's center is outside of WGS84 bounds.\n"
             msg += "Is data in WGS84 projection?"

--- a/lonboard/_layer.py
+++ b/lonboard/_layer.py
@@ -156,7 +156,7 @@ class BaseArrowLayer(BaseLayer):
             self._bbox = default_viewport[0]
             self._weighted_centroid = default_viewport[1]
 
-        super().__init__(**kwargs)
+        super().__init__(table=table, **kwargs)
 
     @traitlets.default("_rows_per_chunk")
     def _default_rows_per_chunk(self):

--- a/lonboard/_map.py
+++ b/lonboard/_map.py
@@ -130,12 +130,4 @@ class Map(BaseAnyWidget):
 
     @traitlets.default("_initial_view_state")
     def _default_initial_view_state(self):
-        tables = [
-            layer.table
-            for layer in self.layers
-            if hasattr(layer, "table") and layer.table
-        ]
-        if tables:
-            return compute_view(tables)
-        else:
-            return {}
+        return compute_view(self.layers)

--- a/lonboard/_viewport.py
+++ b/lonboard/_viewport.py
@@ -10,36 +10,21 @@ from __future__ import annotations
 import math
 from typing import List, Tuple
 
-import pyarrow as pa
-
-from lonboard._geoarrow.ops.bbox import Bbox, total_bounds
-from lonboard._geoarrow.ops.centroid import WeightedCentroid, weighted_centroid
-from lonboard._utils import get_geometry_column_index
+from lonboard._geoarrow.ops.bbox import Bbox
+from lonboard._geoarrow.ops.centroid import WeightedCentroid
+from lonboard._layer import BaseLayer
 
 
-def get_bbox_center(tables: List[pa.Table]) -> Tuple[Bbox, WeightedCentroid]:
+def get_bbox_center(layers: List[BaseLayer]) -> Tuple[Bbox, WeightedCentroid]:
     """Get the bounding box and geometric (weighted) center of the geometries in the
     table."""
 
     overall_bbox = Bbox()
     overall_centroid = WeightedCentroid()
 
-    for table in tables:
-        # Note: in the ArcLayer we won't necessarily have a column with a geoarrow
-        # extension type/metadata
-        try:
-            geom_col_idx = get_geometry_column_index(table.schema)
-        except ValueError:
-            continue
-
-        geom_field = table.schema.field(geom_col_idx)
-        geom_col = table.column(geom_col_idx)
-
-        table_bbox = total_bounds(geom_field, geom_col)
-        overall_bbox.update(table_bbox)
-
-        table_centroid = weighted_centroid(geom_field, geom_col)
-        overall_centroid.update(table_centroid)
+    for layer in layers:
+        overall_bbox.update(layer._bbox)
+        overall_centroid.update(layer._weighted_centroid)
 
     return overall_bbox, overall_centroid
 
@@ -70,18 +55,9 @@ def bbox_to_zoom_level(bbox: Bbox) -> int:
     return zoom_level
 
 
-def compute_view(tables: List[pa.Table]):
+def compute_view(layers: List[BaseLayer]):
     """Automatically computes a view state for the data passed in."""
-    bbox, center = get_bbox_center(tables)
-
-    if center.x is not None and (center.x < 180 or center.x > 180):
-        msg = "Longitude of data's center is outside of WGS84 bounds.\n"
-        msg += "Is data in WGS84 projection?"
-        raise ValueError(msg)
-    if center.y is not None and (center.y < 90 or center.y > 90):
-        msg = "Latitude of data's center is outside of WGS84 bounds.\n"
-        msg += "Is data in WGS84 projection?"
-        raise ValueError(msg)
+    bbox, center = get_bbox_center(layers)
 
     # When no geo column is found, bbox will have inf values
     try:

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -27,3 +27,12 @@ def test_layer_fails_with_unexpected_argument():
 
     with pytest.raises(TypeError, match="unexpected keyword argument"):
         _layer = ScatterplotLayer.from_geopandas(gdf, unknown_keyword="foo")
+
+
+def test_layer_outside_4326_range():
+    # Table outside of epsg:4326 range
+    points = shapely.points([1000000, 2000000], [3000000, 4000000])
+    gdf = gpd.GeoDataFrame(geometry=points)
+
+    with pytest.raises(ValueError, match="outside of WGS84 bounds"):
+        _layer = ScatterplotLayer.from_geopandas(gdf)


### PR DESCRIPTION
This adds a check on layer creation that the computed centroid of the input data is within the bounds of wgs84. This doesn't check the computed _bounding box_ because that could wrap over the international date line and have values less than -180.

This is improved over the previous approach because previously we checked the _final average_ of the centroid against wgs84, whereas now we check each layer individually. This is safer in case _most_ layers are wgs84 but one is not. Also, it errors at layer creation, which is a much better time to error.

In the future, we could allow web-mercator coordinates as well (see https://deck.gl/docs/developer-guide/coordinate-systems) and this would have to be refactored to allow the larger range of coordinates.