### PR TITLE
Allow passing a positional `layers` object into `Map`

### DIFF
--- a/docs/api/layers/arc-layer.md
+++ b/docs/api/layers/arc-layer.md
@@ -2,5 +2,4 @@
 
 ::: lonboard.experimental.ArcLayer
     options:
-      show_bases: false
       inherited_members: true

--- a/docs/api/layers/base-layer.md
+++ b/docs/api/layers/base-layer.md
@@ -1,0 +1,9 @@
+# Base Classes
+
+::: lonboard.BaseLayer
+    options:
+      inherited_members: true
+
+::: lonboard.BaseArrowLayer
+    options:
+      inherited_members: true

--- a/docs/api/layers/bitmap-layer.md
+++ b/docs/api/layers/bitmap-layer.md
@@ -2,5 +2,4 @@
 
 ::: lonboard.BitmapLayer
     options:
-      show_bases: false
       inherited_members: true

--- a/docs/api/layers/bitmap-tile-layer.md
+++ b/docs/api/layers/bitmap-tile-layer.md
@@ -2,5 +2,4 @@
 
 ::: lonboard.BitmapTileLayer
     options:
-      show_bases: false
       inherited_members: true

--- a/docs/api/layers/heatmap-layer.md
+++ b/docs/api/layers/heatmap-layer.md
@@ -2,5 +2,4 @@
 
 ::: lonboard.HeatmapLayer
     options:
-      show_bases: false
       inherited_members: true

--- a/docs/api/layers/path-layer.md
+++ b/docs/api/layers/path-layer.md
@@ -6,5 +6,4 @@
 
 ::: lonboard.PathLayer
     options:
-      show_bases: false
       inherited_members: true

--- a/docs/api/layers/scatterplot-layer.md
+++ b/docs/api/layers/scatterplot-layer.md
@@ -6,5 +6,4 @@
 
 ::: lonboard.ScatterplotLayer
     options:
-      show_bases: false
       inherited_members: true

--- a/docs/api/layers/solid-polygon-layer.md
+++ b/docs/api/layers/solid-polygon-layer.md
@@ -2,5 +2,4 @@
 
 ::: lonboard.SolidPolygonLayer
     options:
-      show_bases: false
       inherited_members: true

--- a/docs/api/layers/text-layer.md
+++ b/docs/api/layers/text-layer.md
@@ -2,5 +2,4 @@
 
 ::: lonboard.experimental.TextLayer
     options:
-      show_bases: false
       inherited_members: true

--- a/docs/api/map.md
+++ b/docs/api/map.md
@@ -5,5 +5,6 @@ https://mkdocstrings.github.io/python/usage/configuration/members/#filters
 -->
 ::: lonboard.Map
     options:
+      group_by_category: false
       show_bases: false
       filters:

--- a/lonboard/__init__.py
+++ b/lonboard/__init__.py
@@ -3,6 +3,8 @@
 
 from . import colormap, traits
 from ._layer import (
+    BaseArrowLayer,
+    BaseLayer,
     BitmapLayer,
     BitmapTileLayer,
     HeatmapLayer,

--- a/lonboard/_layer.py
+++ b/lonboard/_layer.py
@@ -209,7 +209,7 @@ class BitmapLayer(BaseLayer):
         image='https://raw.githubusercontent.com/visgl/deck.gl-data/master/website/sf-districts.png',
         bounds=[-122.5190, 37.7045, -122.355, 37.829]
     )
-    m = Map(layers=[layer])
+    m = Map(layer)
     m
     ```
     """
@@ -309,7 +309,7 @@ class BitmapTileLayer(BaseLayer):
         min_zoom=0,
         max_zoom=19,
     )
-    m = Map(layers=[layer])
+    m = Map(layer)
     ```
     """
 
@@ -490,7 +490,7 @@ class ScatterplotLayer(BaseArrowLayer):
         gdf,
         get_fill_color=[255, 0, 0],
     )
-    m = Map(layers=[layer])
+    m = Map(layer)
     ```
 
     From [geoarrow-rust](https://geoarrow.github.io/geoarrow-rs/python/latest):
@@ -505,7 +505,7 @@ class ScatterplotLayer(BaseArrowLayer):
         table=table,
         get_fill_color=[255, 0, 0],
     )
-    m = Map(layers=[layer])
+    m = Map(layer)
     ```
     """
 
@@ -711,7 +711,7 @@ class PathLayer(BaseArrowLayer):
         get_color=[255, 0, 0],
         width_min_pixels=2,
     )
-    m = Map(layers=[layer])
+    m = Map(layer)
     ```
 
     From [geoarrow-rust](https://geoarrow.github.io/geoarrow-rs/python/latest):
@@ -727,7 +727,7 @@ class PathLayer(BaseArrowLayer):
         get_color=[255, 0, 0],
         width_min_pixels=2,
     )
-    m = Map(layers=[layer])
+    m = Map(layer)
     ```
     """
 
@@ -870,7 +870,7 @@ class SolidPolygonLayer(BaseArrowLayer):
         gdf,
         get_fill_color=[255, 0, 0],
     )
-    m = Map(layers=[layer])
+    m = Map(layer)
     ```
 
     From [geoarrow-rust](https://geoarrow.github.io/geoarrow-rs/python/latest):
@@ -885,7 +885,7 @@ class SolidPolygonLayer(BaseArrowLayer):
         table=table,
         get_fill_color=[255, 0, 0],
     )
-    m = Map(layers=[layer])
+    m = Map(layer)
     ```
     """
 
@@ -1014,7 +1014,7 @@ class HeatmapLayer(BaseArrowLayer):
     # A GeoDataFrame with Point geometries
     gdf = gpd.GeoDataFrame()
     layer = HeatmapLayer.from_geopandas(gdf)
-    m = Map(layers=[layer])
+    m = Map(layer)
     ```
 
     From [geoarrow-rust](https://geoarrow.github.io/geoarrow-rs/python/latest):
@@ -1029,7 +1029,7 @@ class HeatmapLayer(BaseArrowLayer):
         table=table,
         get_fill_color=[255, 0, 0],
     )
-    m = Map(layers=[layer])
+    m = Map(layer)
     ```
 
     """

--- a/lonboard/_map.py
+++ b/lonboard/_map.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Union
+from typing import Sequence, Union
 
 import ipywidgets
 import traitlets
@@ -41,9 +41,15 @@ class Map(BaseAnyWidget):
         get_fill_color=[255, 0, 0],
     )
 
-    m = Map(layers=[point_layer, polygon_layer])
+    m = Map([point_layer, polygon_layer])
     ```
     """
+
+    def __init__(self, layers: Union[BaseLayer, Sequence[BaseLayer]], **kwargs):
+        if isinstance(layers, BaseLayer):
+            layers = [layers]
+
+        super().__init__(layers=layers, **kwargs)
 
     _esm = bundler_output_dir / "index.js"
     _css = bundler_output_dir / "index.css"

--- a/lonboard/_map.py
+++ b/lonboard/_map.py
@@ -45,7 +45,18 @@ class Map(BaseAnyWidget):
     ```
     """
 
-    def __init__(self, layers: Union[BaseLayer, Sequence[BaseLayer]], **kwargs):
+    def __init__(self, layers: Union[BaseLayer, Sequence[BaseLayer]], **kwargs) -> None:
+        """Create a new Map.
+
+        Aside from the `layers` argument, pass keyword arguments for any other attribute
+        defined in this class.
+
+        Args:
+            layers: One or more layers to render on this map.
+
+        Returns:
+            A Map object.
+        """
         if isinstance(layers, BaseLayer):
             layers = [layers]
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,10 +35,13 @@ nav:
       - api/viz.md
       - api/map.md
       - Layers:
+          - api/layers/bitmap-layer.md
+          - api/layers/bitmap-tile-layer.md
           - api/layers/heatmap-layer.md
           - api/layers/path-layer.md
           - api/layers/scatterplot-layer.md
           - api/layers/solid-polygon-layer.md
+          - api/layers/base-layer.md
       - api/basemap.md
       - api/colormap.md
       - api/traits.md

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -2,7 +2,7 @@ import geopandas as gpd
 import pytest
 import shapely
 
-from lonboard import Map, ScatterplotLayer
+from lonboard import Map, ScatterplotLayer, SolidPolygonLayer
 
 
 def test_map_fails_with_unexpected_argument():
@@ -13,3 +13,17 @@ def test_map_fails_with_unexpected_argument():
 
     with pytest.raises(TypeError, match="unexpected keyword argument"):
         _map = Map(layers=[layer], unknown_keyword="foo")
+
+
+def allow_layers_positional_argument():
+    gdf = gpd.read_file(gpd.datasets.get_path("nybb"))
+
+    layer = SolidPolygonLayer.from_geopandas(gdf)
+    _m = Map([layer])
+
+
+def allow_single_layer():
+    gdf = gpd.read_file(gpd.datasets.get_path("nybb"))
+
+    layer = SolidPolygonLayer.from_geopandas(gdf)
+    _m = Map(layer)


### PR DESCRIPTION
### Change list

- Allow one or more `BaseLayer` objects to be passed into the first positional `Map` argument
- Update documentation
- Add docs page for base classes (`BaseLayer` and `BaseArrowLayer`)
- Add missing docs pages for `BitmapLayer` and `BitmapTileLayer`