### PR TITLE
Fix inferring number of rows per chunk

### DIFF
--- a/lonboard/_layer.py
+++ b/lonboard/_layer.py
@@ -168,6 +168,8 @@ class BaseArrowLayer(BaseLayer):
         if rows_per_chunk <= 0:
             raise ValueError("Cannot serialize table with 0 rows per chunk.")
 
+        self._rows_per_chunk = rows_per_chunk
+
         super().__init__(table=table, **kwargs)
 
     @classmethod

--- a/lonboard/_layer.py
+++ b/lonboard/_layer.py
@@ -149,8 +149,12 @@ class BaseArrowLayer(BaseLayer):
 
     # Note: these class attributes are **not** serialized to JS
 
+    # Number of rows per chunk for serializing table and accessor columns.
+    #
+    # This is a _layer-level_ construct because we need to ensure the main table and all
+    # accessors have exactly the same chunking, because each chunk is rendered
+    # independently as a separate deck.gl layer
     _rows_per_chunk: int
-    """Number of rows per chunk for serializing table and accessor columns."""
 
     # The following traitlets **are** serialized to JS
 

--- a/lonboard/experimental/_layer.py
+++ b/lonboard/experimental/_layer.py
@@ -4,7 +4,7 @@ import pyarrow as pa
 import traitlets
 
 from lonboard._constants import EXTENSION_NAME
-from lonboard._layer import BaseLayer
+from lonboard._layer import BaseArrowLayer
 from lonboard.experimental.traits import PointAccessor
 from lonboard.traits import (
     ColorAccessor,
@@ -14,7 +14,7 @@ from lonboard.traits import (
 )
 
 
-class ArcLayer(BaseLayer):
+class ArcLayer(BaseArrowLayer):
     """Render raised arcs joining pairs of source and target coordinates."""
 
     _layer_type = traitlets.Unicode("arc").tag(sync=True)
@@ -135,7 +135,7 @@ class ArcLayer(BaseLayer):
         return proposal["value"]
 
 
-class TextLayer(BaseLayer):
+class TextLayer(BaseArrowLayer):
     """Render text labels at given coordinates."""
 
     _layer_type = traitlets.Unicode("text").tag(sync=True)

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -2,13 +2,13 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
-from ipywidgets import Widget
 from traitlets import TraitError
 
+from lonboard._layer import BaseLayer
 from lonboard.traits import ColorAccessor, FloatAccessor
 
 
-class ColorAccessorWidget(Widget):
+class ColorAccessorWidget(BaseLayer):
     _rows_per_chunk = 2
 
     color = ColorAccessor()
@@ -115,7 +115,7 @@ def test_color_accessor_validation_string():
         ColorAccessorWidget(color="#ff")
 
 
-class FloatAccessorWidget(Widget):
+class FloatAccessorWidget(BaseLayer):
     _rows_per_chunk = 2
 
     value = FloatAccessor()


### PR DESCRIPTION
We use the `_rows_per_chunk` attribute to determine the number of rows that are included in each Parquet chunk sent to the frontend. This is a _layer-level_ construct because we need to ensure the main table and all accessors have exactly the same chunking, because each chunk is rendered independently as a separate deck.gl layer

We previously had issues where the number of rows per chunk was either not the same across all data objects within a layer, or alternatively a few cases (as with the ArcLayer) where we were accidentally initializing the number of rows per chunk to be `0`, which let to an infinite loop in `table.to_batches(max_chunksize=0)`.