### PR TITLE
DRAFT: add validation in python for NormalAccessor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ static
 .pnp.loader.mjs
 node_modules
 *.h5
+.env
+data.json

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -64,6 +64,14 @@ Anywidget and its dependency ipywidgets handles the serialization from Python in
 
 Push a new tag to the main branch of the format `v*`. A new version will be published to PyPI automatically.
 
+## Contribute
+
+We run linting and formating on all pull requests. You can perform that operation locally with `pre-commit`.
+```
+pip install -U pre-commit
+pre-commit run --all-files
+```
+
 ## Documentation website
 
 The documentation website is generated with `mkdocs` and [`mkdocs-material`](https://squidfunk.github.io/mkdocs-material). After `poetry install`, you can serve the docs website locally with

--- a/lonboard/_serialization.py
+++ b/lonboard/_serialization.py
@@ -62,6 +62,19 @@ def serialize_float_accessor(data: Union[int, float, NDArray[np.floating]], obj)
     assert isinstance(data, (pa.ChunkedArray, pa.Array))
     return serialize_pyarrow_column(data, max_chunksize=obj._rows_per_chunk)
 
+def serialize_normal_accessor(
+        data: Union[List[Union[int,float]],np.ndarray],
+        obj
+    ):
+    if data is None:
+        return None
+    
+    if isinstance(data, list):
+        return data
+    
+    assert isinstance(data, (pa.ChunkedArray, pa.Array))
+    return serialize_pyarrow_column(data,max_chunksize=obj._rows_per_chunk)
+
 
 def serialize_table(data, obj):
     assert isinstance(data, pa.Table), "expected pyarrow table"
@@ -78,3 +91,4 @@ COLOR_SERIALIZATION = {"to_json": serialize_color_accessor}
 # TODO: rename as it's used for text as well
 FLOAT_SERIALIZATION = {"to_json": serialize_float_accessor}
 TABLE_SERIALIZATION = {"to_json": serialize_table}
+NORMAL_SERIALIZATION = {"to_json": serialize_normal_accessor}

--- a/lonboard/_serialization.py
+++ b/lonboard/_serialization.py
@@ -62,18 +62,16 @@ def serialize_float_accessor(data: Union[int, float, NDArray[np.floating]], obj)
     assert isinstance(data, (pa.ChunkedArray, pa.Array))
     return serialize_pyarrow_column(data, max_chunksize=obj._rows_per_chunk)
 
-def serialize_normal_accessor(
-        data: Union[List[Union[int,float]],np.ndarray],
-        obj
-    ):
+
+def serialize_normal_accessor(data: Union[List[Union[int, float]], np.ndarray], obj):
     if data is None:
         return None
-    
+
     if isinstance(data, list):
         return data
-    
+
     assert isinstance(data, (pa.ChunkedArray, pa.Array))
-    return serialize_pyarrow_column(data,max_chunksize=obj._rows_per_chunk)
+    return serialize_pyarrow_column(data, max_chunksize=obj._rows_per_chunk)
 
 
 def serialize_table(data, obj):

--- a/lonboard/experimental/traits.py
+++ b/lonboard/experimental/traits.py
@@ -9,6 +9,7 @@ from traitlets.traitlets import TraitType
 
 from lonboard._serialization import (
     COLOR_SERIALIZATION,
+    NORMAL_SERIALIZATION
 )
 from lonboard.traits import FixedErrorTraitType
 
@@ -99,5 +100,73 @@ class PointAccessor(FixedErrorTraitType):
 
             return tuple(map(int, (np.array(c) * 255).astype(np.uint8)))
 
+        self.error(obj, value)
+        assert False
+
+
+class NormalAccessor(Union[TraitType, FixedErrorTraitType]):
+    """
+        A representation of a deck.gl normal accessor
+        
+        Acceptable inputs:
+        - A numpy ndarray with two dimensions: The size of the second dimension must be 3 i.e. `(N,3)`
+        - a pyarrow `FixedSizeListArray` or `ChunkedArray` containing `FixedSizeListArray`s 
+        where the size of the inner fixed size list 3.
+    """
+    default_value = [0,0,1]
+    info_text = (
+        "List representing normal of each object, in [nx, ny, nz]. or numpy ndarray or "
+        "pyarrow FixedSizeList representing the normal of each object, in [nx, ny, nz]"
+    )
+
+    def __init__(
+        self: TraitType,
+        *args,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.tag(sync=True, **NORMAL_SERIALIZATION)
+        
+    def validate(
+        self, obj, value
+    ) -> Union[Tuple[int, ...], List[int], pa.ChunkedArray, pa.FixedSizeListArray]:
+        
+        
+        # TODO Redundant logic?
+        list_size = value.shape[1]
+        if list_size != 3:
+            self.error(
+                obj,
+                value,
+                info="Point array must have 3 as its second dimension. I.e. (N,3)",
+            )
+        
+        if isinstance(value, np.ndarray):
+            # values must be contiguous (the same length for all values)
+            if value.ndim != 2 or value.shape[1] != 3:
+                self.error(obj, value, info="Normal array must be 2D with shape (N,3)")
+                
+            if not np.any(value == 1):
+                self.error(obj, value, info="One of the normal vector elements must be 1.")
+                
+            return pa.FixedSizeListArray.from_arrays(value.flatten("C"), list_size)
+                
+        if isinstance(value, (pa.ChunkedArray, pa.Array)):
+            if not pa.types.is_fixed_size_list(value.type):
+                self.error(
+                    obj, value, info="Point pyarrow array must be a FixedSizeList."
+                )
+                
+            if value.type.list_size != 3:
+                self.error(
+                    obj,
+                    value,
+                    info=(
+                        "Normal pyarrow array must have a FixedSizeList inner size of 3."
+                    ),
+                )
+
+            return pa.FixedSizeListArray.from_arrays(value.flatten("C"), list_size)
+                
         self.error(obj, value)
         assert False

--- a/lonboard/experimental/traits.py
+++ b/lonboard/experimental/traits.py
@@ -85,7 +85,7 @@ class PointAccessor(FixedErrorTraitType):
         if isinstance(value, str):
             try:
                 c = mpl.colors.to_rgba(value)  # type: ignore
-            except ValueError:
+            except Exception:
                 self.error(
                     obj,
                     value,
@@ -94,7 +94,6 @@ class PointAccessor(FixedErrorTraitType):
                         "matplotlib.colors.to_rgba."
                     ),
                 )
-                return
 
             return tuple(map(int, (np.array(c) * 255).astype(np.uint8)))
 
@@ -102,13 +101,15 @@ class PointAccessor(FixedErrorTraitType):
         assert False
 
 
-class NormalAccessor(Union[TraitType, FixedErrorTraitType]):
+class NormalAccessor(FixedErrorTraitType):
     """
     A representation of a deck.gl normal accessor
 
     Acceptable inputs:
-    - A numpy ndarray with two dimensions: The size of the second dimension must be 3 i.e. `(N,3)`
-    - a pyarrow `FixedSizeListArray` or `ChunkedArray` containing `FixedSizeListArray`s
+    - A numpy ndarray with two dimensions: The size of the
+    second dimension must be 3 i.e. `(N,3)`
+    - a pyarrow `FixedSizeListArray` or
+    `ChunkedArray` containing `FixedSizeListArray`s
     where the size of the inner fixed size list 3.
     """
 
@@ -130,7 +131,8 @@ class NormalAccessor(Union[TraitType, FixedErrorTraitType]):
         self, obj, value
     ) -> Union[Tuple[int, ...], List[int], pa.ChunkedArray, pa.FixedSizeListArray]:
         """
-        Values in acceptable types must be contiguous (the same length for all values) and of floating point type
+        Values in acceptable types must be contiguous
+        (the same length for all values) and of floating point type
         """
 
         fixed_list_size = 3
@@ -155,7 +157,8 @@ class NormalAccessor(Union[TraitType, FixedErrorTraitType]):
 
             if not np.issubdtype(value.dtype, np.float32):
                 warnings.warn(
-                    "Warning: Numpy array should be floating point type. Converting to float32 point pyarrow array"
+                    """Warning: Numpy array should be floating point type.
+                    Converting to float32 point pyarrow array"""
                 )
                 value = value.cast(pa.list_(pa.float32()))
 
@@ -172,18 +175,20 @@ class NormalAccessor(Union[TraitType, FixedErrorTraitType]):
                     obj,
                     value,
                     info=(
-                        "Normal pyarrow array must have a FixedSizeList inner size of 3."
+                        """Normal pyarrow array must have a
+                        FixedSizeList inner size of 3."""
                     ),
                 )
 
             if not pa.types.is_floating(value.type.value_type):
                 try:
                     value = value.cast(pa.list_(pa.float32()))
-                except:
+                except Exception:
                     self.error(
                         obj,
                         value,
-                        info="Failed to convert array values to floating point type",
+                        info="""Failed to convert array
+                        values to floating point type""",
                     )
 
                 return pa.FixedSizeListArray.from_arrays(value, fixed_list_size)


### PR DESCRIPTION
Draft PR to add NormalAccessor validation to Python experimental traits in `lonboard`.

I had some unrelated git history issues as I renamed the local repository to help stay organized, hence the branch name.