### PR TITLE
Fix null checks

### DIFF
--- a/lonboard/_layer.py
+++ b/lonboard/_layer.py
@@ -1,3 +1,12 @@
+"""Notes:
+
+- When we pass a value of `None` as a default value to a trait, that value will be
+  serialized to JS as `null` and will not be passed into the GeoArrow model (see the
+  lengthy assignments of type `..(this.param !== null && { param: this.param })`). Then
+  the default value in the JS GeoArrow layer (defined in `@geoarrow/deck.gl-layers`)
+  will be used.
+"""
+
 from __future__ import annotations
 
 import sys
@@ -607,7 +616,7 @@ class ScatterplotLayer(BaseArrowLayer):
     - Default: `'meters'`
     """
 
-    radius_scale = traitlets.Float(allow_none=True, min=0).tag(sync=True)
+    radius_scale = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     A global radius multiplier for all points.
 
@@ -615,7 +624,7 @@ class ScatterplotLayer(BaseArrowLayer):
     - Default: `1`
     """
 
-    radius_min_pixels = traitlets.Float(allow_none=True, min=0).tag(sync=True)
+    radius_min_pixels = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     The minimum radius in pixels. This can be used to prevent the circle from getting
     too small when zoomed out.
@@ -624,7 +633,7 @@ class ScatterplotLayer(BaseArrowLayer):
     - Default: `0`
     """
 
-    radius_max_pixels = traitlets.Float(allow_none=True, min=0).tag(sync=True)
+    radius_max_pixels = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     The maximum radius in pixels. This can be used to prevent the circle from getting
     too big when zoomed in.
@@ -643,7 +652,7 @@ class ScatterplotLayer(BaseArrowLayer):
     - Default: `'meters'`
     """
 
-    line_width_scale = traitlets.Float(allow_none=True, min=0).tag(sync=True)
+    line_width_scale = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     A global line width multiplier for all points.
 
@@ -651,7 +660,7 @@ class ScatterplotLayer(BaseArrowLayer):
     - Default: `1`
     """
 
-    line_width_min_pixels = traitlets.Float(allow_none=True, min=0).tag(sync=True)
+    line_width_min_pixels = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     The minimum line width in pixels. This can be used to prevent the stroke from
     getting too thin when zoomed out.
@@ -660,7 +669,7 @@ class ScatterplotLayer(BaseArrowLayer):
     - Default: `0`
     """
 
-    line_width_max_pixels = traitlets.Float(allow_none=True, min=0).tag(sync=True)
+    line_width_max_pixels = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     The maximum line width in pixels. This can be used to prevent the stroke from
     getting too thick when zoomed in.
@@ -669,7 +678,7 @@ class ScatterplotLayer(BaseArrowLayer):
     - Default: `None`
     """
 
-    stroked = traitlets.Bool(allow_none=True).tag(sync=True)
+    stroked = traitlets.Bool(None, allow_none=True).tag(sync=True)
     """
     Draw the outline of points.
 
@@ -677,7 +686,7 @@ class ScatterplotLayer(BaseArrowLayer):
     - Default: `False`
     """
 
-    filled = traitlets.Bool(allow_none=True).tag(sync=True)
+    filled = traitlets.Bool(None, allow_none=True).tag(sync=True)
     """
     Draw the filled area of points.
 
@@ -685,7 +694,7 @@ class ScatterplotLayer(BaseArrowLayer):
     - Default: `True`
     """
 
-    billboard = traitlets.Bool(allow_none=True).tag(sync=True)
+    billboard = traitlets.Bool(None, allow_none=True).tag(sync=True)
     """
     If `True`, rendered circles always face the camera. If `False` circles face up (i.e.
     are parallel with the ground plane).
@@ -694,7 +703,7 @@ class ScatterplotLayer(BaseArrowLayer):
     - Default: `False`
     """
 
-    antialiasing = traitlets.Bool(allow_none=True).tag(sync=True)
+    antialiasing = traitlets.Bool(None, allow_none=True).tag(sync=True)
     """
     If `True`, circles are rendered with smoothed edges. If `False`, circles are
     rendered with rough edges. Antialiasing can cause artifacts on edges of overlapping
@@ -823,7 +832,7 @@ class PathLayer(BaseArrowLayer):
     [`from_geopandas`][lonboard.PathLayer.from_geopandas] instead.
     """
 
-    width_units = traitlets.Unicode(allow_none=True).tag(sync=True)
+    width_units = traitlets.Unicode(None, allow_none=True).tag(sync=True)
     """
     The units of the line width, one of `'meters'`, `'common'`, and `'pixels'`. See
     [unit
@@ -833,7 +842,7 @@ class PathLayer(BaseArrowLayer):
     - Default: `'meters'`
     """
 
-    width_scale = traitlets.Float(allow_none=True, min=0).tag(sync=True)
+    width_scale = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     The path width multiplier that multiplied to all paths.
 
@@ -841,7 +850,7 @@ class PathLayer(BaseArrowLayer):
     - Default: `1`
     """
 
-    width_min_pixels = traitlets.Float(allow_none=True, min=0).tag(sync=True)
+    width_min_pixels = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     The minimum path width in pixels. This prop can be used to prevent the path from
     getting too thin when zoomed out.
@@ -850,7 +859,7 @@ class PathLayer(BaseArrowLayer):
     - Default: `0`
     """
 
-    width_max_pixels = traitlets.Float(allow_none=True, min=0).tag(sync=True)
+    width_max_pixels = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     The maximum path width in pixels. This prop can be used to prevent the path from
     getting too thick when zoomed in.
@@ -859,7 +868,7 @@ class PathLayer(BaseArrowLayer):
     - Default: `None`
     """
 
-    joint_rounded = traitlets.Bool(allow_none=True).tag(sync=True)
+    joint_rounded = traitlets.Bool(None, allow_none=True).tag(sync=True)
     """
     Type of joint. If `True`, draw round joints. Otherwise draw miter joints.
 
@@ -867,7 +876,7 @@ class PathLayer(BaseArrowLayer):
     - Default: `False`
     """
 
-    cap_rounded = traitlets.Bool(allow_none=True).tag(sync=True)
+    cap_rounded = traitlets.Bool(None, allow_none=True).tag(sync=True)
     """
     Type of caps. If `True`, draw round caps. Otherwise draw square caps.
 
@@ -875,7 +884,7 @@ class PathLayer(BaseArrowLayer):
     - Default: `False`
     """
 
-    miter_limit = traitlets.Int(allow_none=True).tag(sync=True)
+    miter_limit = traitlets.Int(None, allow_none=True).tag(sync=True)
     """
     The maximum extent of a joint in ratio to the stroke width.
     Only works if `jointRounded` is `False`.
@@ -884,7 +893,7 @@ class PathLayer(BaseArrowLayer):
     - Default: `4`
     """
 
-    billboard = traitlets.Bool(allow_none=True).tag(sync=True)
+    billboard = traitlets.Bool(None, allow_none=True).tag(sync=True)
     """
     If `True`, extrude the path in screen space (width always faces the camera).
     If `False`, the width always faces up.
@@ -978,7 +987,7 @@ class SolidPolygonLayer(BaseArrowLayer):
     [`from_geopandas`][lonboard.SolidPolygonLayer.from_geopandas] instead.
     """
 
-    filled = traitlets.Bool(allow_none=True).tag(sync=True)
+    filled = traitlets.Bool(None, allow_none=True).tag(sync=True)
     """
     Whether to fill the polygons (based on the color provided by the
     `get_fill_color` accessor).
@@ -987,7 +996,7 @@ class SolidPolygonLayer(BaseArrowLayer):
     - Default: `True`
     """
 
-    extruded = traitlets.Bool(allow_none=True).tag(sync=True)
+    extruded = traitlets.Bool(None, allow_none=True).tag(sync=True)
     """
     Whether to extrude the polygons (based on the elevations provided by the
     `get_elevation` accessor'). If set to `False`, all polygons will be flat, this
@@ -998,7 +1007,7 @@ class SolidPolygonLayer(BaseArrowLayer):
     - Default: `False`
     """
 
-    wireframe = traitlets.Bool(allow_none=True).tag(sync=True)
+    wireframe = traitlets.Bool(None, allow_none=True).tag(sync=True)
     """
     Whether to generate a line wireframe of the polygon. The outline will have
     "horizontal" lines closing the top and bottom polygons and a vertical line
@@ -1008,7 +1017,7 @@ class SolidPolygonLayer(BaseArrowLayer):
     - Default: `False`
     """
 
-    elevation_scale = traitlets.Float(allow_none=True, min=0).tag(sync=True)
+    elevation_scale = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     Elevation multiplier. The final elevation is calculated by `elevation_scale *
     get_elevation(d)`. `elevation_scale` is a handy property to scale all elevation
@@ -1126,7 +1135,7 @@ class HeatmapLayer(BaseArrowLayer):
     [`from_geopandas`][lonboard.HeatmapLayer.from_geopandas] instead.
     """
 
-    radius_pixels = traitlets.Float(allow_none=True).tag(sync=True)
+    radius_pixels = traitlets.Float(None, allow_none=True).tag(sync=True)
     """Radius of the circle in pixels, to which the weight of an object is distributed.
 
     - Type: `float`, optional
@@ -1140,7 +1149,7 @@ class HeatmapLayer(BaseArrowLayer):
     # - Default: `6-class YlOrRd` - [colorbrewer](http://colorbrewer2.org/#type=sequential&scheme=YlOrRd&n=6)
     # """
 
-    intensity = traitlets.Float(allow_none=True).tag(sync=True)
+    intensity = traitlets.Float(None, allow_none=True).tag(sync=True)
     """
     Value that is multiplied with the total weight at a pixel to obtain the final
     weight.
@@ -1149,7 +1158,7 @@ class HeatmapLayer(BaseArrowLayer):
     - Default: `1`
     """
 
-    threshold = traitlets.Float(allow_none=True, min=0, max=1).tag(sync=True)
+    threshold = traitlets.Float(None, allow_none=True, min=0, max=1).tag(sync=True)
     """Ratio of the fading weight to the max weight, between `0` and `1`.
 
     For example, `0.1` affects all pixels with weight under 10% of the max.
@@ -1171,7 +1180,7 @@ class HeatmapLayer(BaseArrowLayer):
     # - Default: `None`
     # """
 
-    aggregation = traitlets.Unicode(allow_none=True).tag(sync=True)
+    aggregation = traitlets.Unicode(None, allow_none=True).tag(sync=True)
     """Defines the type of aggregation operation
 
     Valid values are 'SUM', 'MEAN'.
@@ -1180,14 +1189,14 @@ class HeatmapLayer(BaseArrowLayer):
     - Default: `"SUM"`
     """
 
-    weights_texture_size = traitlets.Int(allow_none=True).tag(sync=True)
+    weights_texture_size = traitlets.Int(None, allow_none=True).tag(sync=True)
     """Specifies the size of weight texture.
 
     - Type: `int`, optional
     - Default: `2048`
     """
 
-    debounce_timeout = traitlets.Int(allow_none=True).tag(sync=True)
+    debounce_timeout = traitlets.Int(None, allow_none=True).tag(sync=True)
     """
     Interval in milliseconds during which changes to the viewport don't trigger
     aggregation.

--- a/lonboard/_layer.py
+++ b/lonboard/_layer.py
@@ -607,7 +607,7 @@ class ScatterplotLayer(BaseArrowLayer):
     [`from_geopandas`][lonboard.ScatterplotLayer.from_geopandas] instead.
     """
 
-    radius_units = traitlets.Unicode("meters", allow_none=True).tag(sync=True)
+    radius_units = traitlets.Unicode(None, allow_none=True).tag(sync=True)
     """
     The units of the radius, one of `'meters'`, `'common'`, and `'pixels'`. See [unit
     system](https://deck.gl/docs/developer-guide/coordinate-systems#supported-units).
@@ -642,7 +642,7 @@ class ScatterplotLayer(BaseArrowLayer):
     - Default: `None`
     """
 
-    line_width_units = traitlets.Unicode("meters", allow_none=True).tag(sync=True)
+    line_width_units = traitlets.Unicode(None, allow_none=True).tag(sync=True)
     """
     The units of the line width, one of `'meters'`, `'common'`, and `'pixels'`. See
     [unit
@@ -713,7 +713,7 @@ class ScatterplotLayer(BaseArrowLayer):
     - Default: `True`
     """
 
-    get_radius = FloatAccessor()
+    get_radius = FloatAccessor(None, allow_none=True)
     """
     The radius of each object, in units specified by `radius_units` (default
     `'meters'`).
@@ -725,7 +725,7 @@ class ScatterplotLayer(BaseArrowLayer):
     - Default: `1`.
     """
 
-    get_fill_color = ColorAccessor()
+    get_fill_color = ColorAccessor(None, allow_none=True)
     """
     The filled color of each object in the format of `[r, g, b, [a]]`. Each channel is a
     number between 0-255 and `a` is 255 if not supplied.
@@ -738,7 +738,7 @@ class ScatterplotLayer(BaseArrowLayer):
     - Default: `[0, 0, 0, 255]`.
     """
 
-    get_line_color = ColorAccessor()
+    get_line_color = ColorAccessor(None, allow_none=True)
     """
     The outline color of each object in the format of `[r, g, b, [a]]`. Each channel is
     a number between 0-255 and `a` is 255 if not supplied.
@@ -751,7 +751,7 @@ class ScatterplotLayer(BaseArrowLayer):
     - Default: `[0, 0, 0, 255]`.
     """
 
-    get_line_width = FloatAccessor()
+    get_line_width = FloatAccessor(None, allow_none=True)
     """
     The width of the outline of each object, in units specified by `line_width_units`
     (default `'meters'`).
@@ -902,7 +902,7 @@ class PathLayer(BaseArrowLayer):
     - Default: `False`
     """
 
-    get_color = ColorAccessor()
+    get_color = ColorAccessor(None, allow_none=True)
     """
     The color of each path in the format of `[r, g, b, [a]]`. Each channel is a number
     between 0-255 and `a` is 255 if not supplied.
@@ -915,7 +915,7 @@ class PathLayer(BaseArrowLayer):
     - Default: `[0, 0, 0, 255]`.
     """
 
-    get_width = FloatAccessor()
+    get_width = FloatAccessor(None, allow_none=True)
     """
     The width of each path, in units specified by `width_units` (default `'meters'`).
 
@@ -1033,7 +1033,7 @@ class SolidPolygonLayer(BaseArrowLayer):
       with the same data if you want a combined rendering effect.
     """
 
-    get_elevation = FloatAccessor()
+    get_elevation = FloatAccessor(None, allow_none=True)
     """
     The elevation to extrude each polygon with, in meters.
 
@@ -1046,7 +1046,7 @@ class SolidPolygonLayer(BaseArrowLayer):
     - Default: `1000`.
     """
 
-    get_fill_color = ColorAccessor()
+    get_fill_color = ColorAccessor(None, allow_none=True)
     """
     The fill color of each polygon in the format of `[r, g, b, [a]]`. Each channel is a
     number between 0-255 and `a` is 255 if not supplied.
@@ -1059,7 +1059,7 @@ class SolidPolygonLayer(BaseArrowLayer):
     - Default: `[0, 0, 0, 255]`.
     """
 
-    get_line_color = ColorAccessor()
+    get_line_color = ColorAccessor(None, allow_none=True)
     """
     The line color of each polygon in the format of `[r, g, b, [a]]`. Each channel is a
     number between 0-255 and `a` is 255 if not supplied.
@@ -1205,7 +1205,7 @@ class HeatmapLayer(BaseArrowLayer):
     - Default: `500`
     """
 
-    get_weight = FloatAccessor()
+    get_weight = FloatAccessor(None, allow_none=True)
     """The weight of each object.
 
     - Type: [FloatAccessor][lonboard.traits.FloatAccessor], optional

--- a/lonboard/experimental/_layer.py
+++ b/lonboard/experimental/_layer.py
@@ -204,19 +204,19 @@ class TextLayer(BaseArrowLayer):
     # - Default: `False`
     # """
 
-    get_background_color = ColorAccessor()
+    get_background_color = ColorAccessor(None, allow_none=True)
     """Background color accessor.
 
     default [255, 255, 255, 255]
     """
 
-    get_border_color = ColorAccessor()
+    get_border_color = ColorAccessor(None, allow_none=True)
     """Border color accessor.
 
     default [0, 0, 0, 255]
     """
 
-    get_border_width = FloatAccessor()
+    get_border_width = FloatAccessor(None, allow_none=True)
     """Border width accessor.
 
     default 0
@@ -300,7 +300,7 @@ class TextLayer(BaseArrowLayer):
     default -1
     """
 
-    get_text = TextAccessor()
+    get_text = TextAccessor(None, allow_none=True)
     """Label text accessor"""
 
     # get_position = traitlets.Any(None, allow_none=True).tag(sync=True)
@@ -308,19 +308,19 @@ class TextLayer(BaseArrowLayer):
 
     #  ?: Accessor<DataT, Position>;
 
-    get_color = ColorAccessor()
+    get_color = ColorAccessor(None, allow_none=True)
     """Label color accessor
 
     default [0, 0, 0, 255]
     """
 
-    get_size = FloatAccessor()
+    get_size = FloatAccessor(None, allow_none=True)
     """Label size accessor
 
     default 32
     """
 
-    get_angle = FloatAccessor()
+    get_angle = FloatAccessor(None, allow_none=True)
     """Label rotation accessor, in degrees
 
     default 0

--- a/lonboard/experimental/_layer.py
+++ b/lonboard/experimental/_layer.py
@@ -1,3 +1,8 @@
+"""Notes:
+
+- See module docstring of lonboard._layer for note on passing None as default value.
+"""
+
 from __future__ import annotations
 
 import pyarrow as pa
@@ -30,21 +35,21 @@ class ArcLayer(BaseArrowLayer):
     [`from_geopandas`][lonboard.ScatterplotLayer.from_geopandas] instead.
     """
 
-    great_circle = traitlets.Bool(allow_none=True).tag(sync=True)
+    great_circle = traitlets.Bool(None, allow_none=True).tag(sync=True)
     """If `True`, create the arc along the shortest path on the earth surface.
 
     - Type: `bool`, optional
     - Default: `False`
     """
 
-    num_segments = traitlets.Int(allow_none=True).tag(sync=True)
+    num_segments = traitlets.Int(None, allow_none=True).tag(sync=True)
     """The number of segments used to draw each arc.
 
     - Type: `int`, optional
     - Default: `50`
     """
 
-    width_units = traitlets.Unicode(allow_none=True).tag(sync=True)
+    width_units = traitlets.Unicode(None, allow_none=True).tag(sync=True)
     """
     The units of the line width, one of `'meters'`, `'common'`, and `'pixels'`. See
     [unit
@@ -54,7 +59,7 @@ class ArcLayer(BaseArrowLayer):
     - Default: `'pixels'`
     """
 
-    width_scale = traitlets.Float(allow_none=True, min=0).tag(sync=True)
+    width_scale = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     The scaling multiplier for the width of each line.
 
@@ -62,14 +67,14 @@ class ArcLayer(BaseArrowLayer):
     - Default: `1`
     """
 
-    width_min_pixels = traitlets.Float(allow_none=True, min=0).tag(sync=True)
+    width_min_pixels = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
     """The minimum line width in pixels.
 
     - Type: `float`, optional
     - Default: `0`
     """
 
-    width_max_pixels = traitlets.Float(allow_none=True, min=0).tag(sync=True)
+    width_max_pixels = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
     """The maximum line width in pixels.
 
     - Type: `float`, optional
@@ -151,21 +156,21 @@ class TextLayer(BaseArrowLayer):
     [`from_geopandas`][lonboard.ScatterplotLayer.from_geopandas] instead.
     """
 
-    billboard = traitlets.Bool().tag(sync=True)
+    billboard = traitlets.Bool(None, allow_none=True).tag(sync=True)
     """If `true`, the text always faces camera. Otherwise the text faces up (z).
 
     - Type: `bool`
     - Default: `True`
     """
 
-    size_scale = traitlets.Any().tag(sync=True)
+    size_scale = traitlets.Any(None, allow_none=True).tag(sync=True)
     """Text size multiplier.
 
     - Type: `float`.
     - Default: `1`
     """
 
-    size_units = traitlets.Any().tag(sync=True)
+    size_units = traitlets.Any(None, allow_none=True).tag(sync=True)
     """The units of the size, one of `'meters'`, `'common'`, and `'pixels'`.
     default 'pixels'. See [unit
     system](https://deck.gl/docs/developer-guide/coordinate-systems#supported-units).
@@ -174,7 +179,7 @@ class TextLayer(BaseArrowLayer):
     - Default: `'pixels'`
     """
 
-    size_min_pixels = traitlets.Any().tag(sync=True)
+    size_min_pixels = traitlets.Any(None, allow_none=True).tag(sync=True)
     """
     The minimum size in pixels. When using non-pixel `sizeUnits`, this prop can be used
     to prevent the icon from getting too small when zoomed out.
@@ -183,7 +188,7 @@ class TextLayer(BaseArrowLayer):
     - Default: `0`
     """
 
-    size_max_pixels = traitlets.Any().tag(sync=True)
+    size_max_pixels = traitlets.Any(None, allow_none=True).tag(sync=True)
     """
     The maximum size in pixels. When using non-pixel `sizeUnits`, this prop can be used
     to prevent the icon from getting too big when zoomed in.
@@ -192,7 +197,7 @@ class TextLayer(BaseArrowLayer):
     - Default: `None`
     """
 
-    # background = traitlets.Bool().tag(sync=True)
+    # background = traitlets.Bool(None, allow_none=True).tag(sync=True)
     # """Whether to render background for the text blocks.
 
     # - Type: `bool`
@@ -217,7 +222,7 @@ class TextLayer(BaseArrowLayer):
     default 0
     """
 
-    background_padding = traitlets.Any().tag(sync=True)
+    background_padding = traitlets.Any(None, allow_none=True).tag(sync=True)
     """The padding of the background.
 
     - If an array of 2 is supplied, it is interpreted as `[padding_x, padding_y]` in
@@ -228,7 +233,7 @@ class TextLayer(BaseArrowLayer):
     default [0, 0, 0, 0]
     """
 
-    character_set = traitlets.Any().tag(sync=True)
+    character_set = traitlets.Any(None, allow_none=True).tag(sync=True)
     """
     Specifies a list of characters to include in the font. If set to 'auto', will be
     automatically generated from the data set.
@@ -236,25 +241,25 @@ class TextLayer(BaseArrowLayer):
     default (ASCII characters 32-128)
     """
 
-    font_family = traitlets.Any().tag(sync=True)
+    font_family = traitlets.Any(None, allow_none=True).tag(sync=True)
     """CSS font family
 
     default 'Monaco, monospace'
     """
 
-    font_weight = traitlets.Any().tag(sync=True)
+    font_weight = traitlets.Any(None, allow_none=True).tag(sync=True)
     """CSS font weight
 
     default 'normal'
     """
 
-    line_height = traitlets.Any().tag(sync=True)
+    line_height = traitlets.Any(None, allow_none=True).tag(sync=True)
     """
     A unitless number that will be multiplied with the current text size to set the line
     height.
     """
 
-    outline_width = traitlets.Any().tag(sync=True)
+    outline_width = traitlets.Any(None, allow_none=True).tag(sync=True)
     """
     Width of outline around the text, relative to the text size. Only effective if
     `fontSettings.sdf` is `true`.
@@ -262,7 +267,7 @@ class TextLayer(BaseArrowLayer):
     default 0
     """
 
-    outline_color = traitlets.Any().tag(sync=True)
+    outline_color = traitlets.Any(None, allow_none=True).tag(sync=True)
     """
     Color of outline around the text, in `[r, g, b, [a]]`. Each channel is a number
     between 0-255 and `a` is 255 if not supplied.
@@ -270,13 +275,13 @@ class TextLayer(BaseArrowLayer):
     default [0, 0, 0, 255]
     """
 
-    font_settings = traitlets.Any().tag(sync=True)
+    font_settings = traitlets.Any(None, allow_none=True).tag(sync=True)
     """
     Advance options for fine tuning the appearance and performance of the generated
     shared `fontAtlas`.
     """
 
-    word_break = traitlets.Any().tag(sync=True)
+    word_break = traitlets.Any(None, allow_none=True).tag(sync=True)
     """
     Available options are `break-all` and `break-word`. A valid `maxWidth` has to be
     provided to use `wordBreak`.
@@ -284,7 +289,7 @@ class TextLayer(BaseArrowLayer):
     default 'break-word'
     """
 
-    max_width = traitlets.Any().tag(sync=True)
+    max_width = traitlets.Any(None, allow_none=True).tag(sync=True)
     """
     A unitless number that will be multiplied with the current text size to set the
     width limit of a string.
@@ -298,7 +303,7 @@ class TextLayer(BaseArrowLayer):
     get_text = TextAccessor()
     """Label text accessor"""
 
-    # get_position = traitlets.Any().tag(sync=True)
+    # get_position = traitlets.Any(None, allow_none=True).tag(sync=True)
     # """Anchor position accessor"""
 
     #  ?: Accessor<DataT, Position>;
@@ -321,21 +326,21 @@ class TextLayer(BaseArrowLayer):
     default 0
     """
 
-    get_text_anchor = traitlets.Any().tag(sync=True)
+    get_text_anchor = traitlets.Any(None, allow_none=True).tag(sync=True)
     """Horizontal alignment accessor
 
     default 'middle'
     """
     #  ?: Accessor<DataT, 'start' | 'middle' | 'end'>;
 
-    get_alignment_baseline = traitlets.Any().tag(sync=True)
+    get_alignment_baseline = traitlets.Any(None, allow_none=True).tag(sync=True)
     """Vertical alignment accessor
 
     default 'center'
     """
     #  ?: Accessor<DataT, 'top' | 'center' | 'bottom'>;
 
-    get_pixel_offset = traitlets.Any().tag(sync=True)
+    get_pixel_offset = traitlets.Any(None, allow_none=True).tag(sync=True)
     """Label offset from the anchor position, [x, y] in pixels
 
     default [0, 0]

--- a/lonboard/experimental/layer_extension.py
+++ b/lonboard/experimental/layer_extension.py
@@ -1,6 +1,7 @@
 import traitlets
 
 from lonboard._base import BaseExtension
+from lonboard.experimental.traits import PointAccessor
 from lonboard.traits import FloatAccessor
 
 
@@ -8,6 +9,11 @@ class BrushingExtension(BaseExtension):
     """
     Adds GPU-based data brushing functionalities to layers. It allows the layer to
     show/hide objects based on the current pointer position.
+
+    # Example
+
+    An example is in the [County-to-County Migration
+    notebook](https://developmentseed.org/lonboard/latest/examples/migration/).
 
     # Layer Properties
 
@@ -23,13 +29,26 @@ class BrushingExtension(BaseExtension):
 
     ## `brushing_target`
 
-    The position used to filter each object by.
+    The position used to filter each object by. One of the following:
+
+    - `"source"`: Use the primary position for each object. This can mean different
+      things depending on the layer. It usually refers to the coordinates returned by
+      `getPosition` or `getSourcePosition` accessors.
+    - `"target"`: Use the secondary position for each object. This may not be available
+      in some layers. It usually refers to the coordinates returned by
+      `getTargetPosition` accessor.
+    - `"source_target"`: Use both the primary position and secondary position for each
+      object. Show object if either is in brushing range.
+    - `"custom"`: Some layers may not describe their data objects with one or two
+      coordinates, for example `PathLayer` and `PolygonLayer`. Use this option with the
+      `get_brushing_target` prop to provide a custom position that each object should be
+      filtered by.
 
     - Type: `str`, optional
 
-        One of: 'source' | 'target' | 'source_target' | 'custom'
+        One of: "source" | "target" | "source_target" | "custom"
 
-    - Default: `10000`
+    - Default: `"source"`
 
     ## `brushing_radius`
 
@@ -39,28 +58,27 @@ class BrushingExtension(BaseExtension):
     - Type: `float`, optional
     - Default: `10000`
 
-    An example is in the [County-to-County Migration
-    notebook](https://developmentseed.org/lonboard/latest/examples/migration/).
+    ## `get_brushing_target`
+
+    An arbitrary position for each object that it will be filtered by.
+
+    Only effective if `brushing_target` is set to `"custom"`.
+
+    - Type: [PointAccessor][lonboard.experimental.traits.PointAccessor], optional
+        - If a point is provided, it is used as the target for all rows.
+        - If an array of points is provided, each value in the array will be used as the
+          target for the row at the same row index.
+    - Default: `None`.
     """
 
     _extension_type = traitlets.Unicode("brushing").tag(sync=True)
 
     _layer_traits = {
         "brushing_enabled": traitlets.Bool(True).tag(sync=True),
-        "brushing_target": traitlets.Unicode("source", allow_none=True).tag(sync=True),
-        "brushing_radius": traitlets.Float(allow_none=True, min=0).tag(sync=True),
-        # TODO: Add trait and support
-        # "get_brushing_target": traitlets.Any(allow_none=True).tag(sync=True),
+        "brushing_target": traitlets.Unicode(None, allow_none=True).tag(sync=True),
+        "brushing_radius": traitlets.Float(None, allow_none=True, min=0).tag(sync=True),
+        "get_brushing_target": PointAccessor(None, allow_none=True),
     }
-
-    # TODO: update trait
-    # get_brushing_target = traitlets.Any(allow_none=True).tag(sync=True)
-    """
-    Called to retrieve an arbitrary position for each object that it will be filtered
-    by.
-
-    Only effective if `brushingTarget` is set to `"custom"`.
-    """
 
 
 class CollisionFilterExtension(BaseExtension):
@@ -103,8 +121,8 @@ class CollisionFilterExtension(BaseExtension):
 
     _layer_traits = {
         "collision_enabled": traitlets.Bool(True).tag(sync=True),
-        "collision_group": traitlets.Unicode().tag(sync=True),
-        "get_collision_priority": FloatAccessor(allow_none=True),
+        "collision_group": traitlets.Unicode(None, allow_none=True).tag(sync=True),
+        "get_collision_priority": FloatAccessor(None, allow_none=True),
     }
 
 

--- a/src/model/base-layer.ts
+++ b/src/model/base-layer.ts
@@ -47,7 +47,10 @@ export abstract class BaseLayerModel extends BaseModel {
   extensionProps() {
     let props: Record<string, any> = {};
     for (const layerPropertyName of this.extensionLayerPropertyNames) {
-      if (this[layerPropertyName as keyof this] !== undefined) {
+      if (
+        this[layerPropertyName as keyof this] !== undefined &&
+        this[layerPropertyName as keyof this] !== null
+      ) {
         props[layerPropertyName] = this[layerPropertyName as keyof this];
       }
     }

--- a/src/model/base-layer.ts
+++ b/src/model/base-layer.ts
@@ -94,14 +94,12 @@ export abstract class BaseLayerModel extends BaseModel {
   // experimental
   async initLayerExtensions() {
     const initExtensionsCallback = async () => {
-      console.log("initExtensionsCallback");
       const childModelIds = this.model.get("extensions");
       if (!childModelIds) {
         this.extensions = [];
         return;
       }
 
-      console.log(childModelIds);
       const childModels = await loadChildModels(
         this.model.widget_manager,
         childModelIds,

--- a/src/model/layer.ts
+++ b/src/model/layer.ts
@@ -545,8 +545,6 @@ export class ScatterplotModel extends BaseArrowLayerModel {
   }
 
   layerProps(): Omit<GeoArrowScatterplotLayerProps, "id"> {
-    console.log("stroked", this.stroked);
-
     return {
       data: this.table,
       ...(this.radiusUnits !== null && { radiusUnits: this.radiusUnits }),

--- a/src/model/layer.ts
+++ b/src/model/layer.ts
@@ -95,23 +95,28 @@ export class ArcModel extends BaseArrowLayerModel {
   layerProps(): Omit<GeoArrowArcLayerProps, "id"> {
     return {
       data: this.table,
-      ...(this.greatCircle && { greatCircle: this.greatCircle }),
-      ...(this.numSegments && { numSegments: this.numSegments }),
-      ...(this.widthUnits && { widthUnits: this.widthUnits }),
-      ...(this.widthScale && { widthScale: this.widthScale }),
-      ...(this.widthMinPixels && { widthMinPixels: this.widthMinPixels }),
-      ...(this.widthMaxPixels && { widthMaxPixels: this.widthMaxPixels }),
-      ...(this.getSourcePosition && {
-        getSourcePosition: this.getSourcePosition,
+      // Always provided
+      getSourcePosition: this.getSourcePosition,
+      getTargetPosition: this.getTargetPosition,
+      ...(this.greatCircle !== null && { greatCircle: this.greatCircle }),
+      ...(this.numSegments !== null && { numSegments: this.numSegments }),
+      ...(this.widthUnits !== null && { widthUnits: this.widthUnits }),
+      ...(this.widthScale !== null && { widthScale: this.widthScale }),
+      ...(this.widthMinPixels !== null && {
+        widthMinPixels: this.widthMinPixels,
       }),
-      ...(this.getTargetPosition && {
-        getTargetPosition: this.getTargetPosition,
+      ...(this.widthMaxPixels !== null && {
+        widthMaxPixels: this.widthMaxPixels,
       }),
-      ...(this.getSourceColor && { getSourceColor: this.getSourceColor }),
-      ...(this.getTargetColor && { getTargetColor: this.getTargetColor }),
-      ...(this.getWidth && { getWidth: this.getWidth }),
-      ...(this.getHeight && { getHeight: this.getHeight }),
-      ...(this.getTilt && { getTilt: this.getTilt }),
+      ...(this.getSourceColor !== null && {
+        getSourceColor: this.getSourceColor,
+      }),
+      ...(this.getTargetColor !== null && {
+        getTargetColor: this.getTargetColor,
+      }),
+      ...(this.getWidth !== null && { getWidth: this.getWidth }),
+      ...(this.getHeight !== null && { getHeight: this.getHeight }),
+      ...(this.getTilt !== null && { getTilt: this.getTilt }),
     };
   }
 
@@ -144,11 +149,13 @@ export class BitmapModel extends BaseLayerModel {
 
   layerProps(): Omit<BitmapLayerProps, "id" | "data"> {
     return {
-      ...(this.image && { image: this.image }),
-      ...(this.bounds && { bounds: this.bounds }),
-      ...(this.desaturate && { desaturate: this.desaturate }),
-      ...(this.transparentColor && { transparentColor: this.transparentColor }),
-      ...(this.tintColor && { tintColor: this.tintColor }),
+      ...(this.image !== null && { image: this.image }),
+      ...(this.bounds !== null && { bounds: this.bounds }),
+      ...(this.desaturate !== null && { desaturate: this.desaturate }),
+      ...(this.transparentColor !== null && {
+        transparentColor: this.transparentColor,
+      }),
+      ...(this.tintColor !== null && { tintColor: this.tintColor }),
     };
   }
 
@@ -201,26 +208,30 @@ export class BitmapTileModel extends BaseLayerModel {
 
   bitmapLayerProps(): Omit<BitmapLayerProps, "id" | "data"> {
     return {
-      ...(this.desaturate && { desaturate: this.desaturate }),
-      ...(this.transparentColor && { transparentColor: this.transparentColor }),
-      ...(this.tintColor && { tintColor: this.tintColor }),
+      ...(this.desaturate !== null && { desaturate: this.desaturate }),
+      ...(this.transparentColor !== null && {
+        transparentColor: this.transparentColor,
+      }),
+      ...(this.tintColor !== null && { tintColor: this.tintColor }),
     };
   }
 
   layerProps(): Omit<TileLayerProps, "id"> {
     return {
       data: this.data,
-      ...(this.tileSize && { tileSize: this.tileSize }),
-      ...(this.zoomOffset && { zoomOffset: this.zoomOffset }),
-      ...(this.maxZoom && { maxZoom: this.maxZoom }),
-      ...(this.minZoom && { minZoom: this.minZoom }),
-      ...(this.extent && { extent: this.extent }),
-      ...(this.maxCacheSize && { maxCacheSize: this.maxCacheSize }),
-      ...(this.maxCacheByteSize && { maxCacheByteSize: this.maxCacheByteSize }),
-      ...(this.refinementStrategy && {
+      ...(this.tileSize !== null && { tileSize: this.tileSize }),
+      ...(this.zoomOffset !== null && { zoomOffset: this.zoomOffset }),
+      ...(this.maxZoom !== null && { maxZoom: this.maxZoom }),
+      ...(this.minZoom !== null && { minZoom: this.minZoom }),
+      ...(this.extent !== null && { extent: this.extent }),
+      ...(this.maxCacheSize !== null && { maxCacheSize: this.maxCacheSize }),
+      ...(this.maxCacheByteSize !== null && {
+        maxCacheByteSize: this.maxCacheByteSize,
+      }),
+      ...(this.refinementStrategy !== null && {
         refinementStrategy: this.refinementStrategy,
       }),
-      ...(this.maxRequests && { maxRequests: this.maxRequests }),
+      ...(this.maxRequests !== null && { maxRequests: this.maxRequests }),
     };
   }
 
@@ -249,7 +260,11 @@ export class ColumnModel extends BaseArrowLayerModel {
   protected diskResolution: GeoArrowColumnLayerProps["diskResolution"] | null;
   protected radius: GeoArrowColumnLayerProps["radius"] | null;
   protected angle: GeoArrowColumnLayerProps["angle"] | null;
-  protected vertices!: GeoArrowColumnLayerProps["vertices"];
+
+  // @ts-expect-error Property 'vertices' has no initializer and is not
+  // definitely assigned in the constructor
+  // Ref https://github.com/visgl/deck.gl/pull/8453
+  protected vertices: GeoArrowColumnLayerProps["vertices"] | null;
   protected offset: GeoArrowColumnLayerProps["offset"] | null;
   protected coverage: GeoArrowColumnLayerProps["coverage"] | null;
   protected elevationScale: GeoArrowColumnLayerProps["elevationScale"] | null;
@@ -304,35 +319,47 @@ export class ColumnModel extends BaseArrowLayerModel {
   }
 
   layerProps(): Omit<GeoArrowColumnLayerProps, "id"> {
+    // @ts-expect-error Type 'Position[] | undefined' is not assignable to type
+    // 'Position[] | null'.
+    // Ref https://github.com/visgl/deck.gl/pull/8453
     return {
       data: this.table,
-      ...(this.diskResolution && { diskResolution: this.diskResolution }),
-      ...(this.radius && { radius: this.radius }),
-      ...(this.angle && { angle: this.angle }),
-      ...(this.vertices! && { vertices: this.vertices }),
-      ...(this.offset && { offset: this.offset }),
-      ...(this.coverage && { coverage: this.coverage }),
-      ...(this.elevationScale && { elevationScale: this.elevationScale }),
-      ...(this.filled && { filled: this.filled }),
-      ...(this.stroked && { stroked: this.stroked }),
-      ...(this.extruded && { extruded: this.extruded }),
-      ...(this.wireframe && { wireframe: this.wireframe }),
-      ...(this.flatShading && { flatShading: this.flatShading }),
-      ...(this.radiusUnits && { radiusUnits: this.radiusUnits }),
-      ...(this.lineWidthUnits && { lineWidthUnits: this.lineWidthUnits }),
-      ...(this.lineWidthScale && { lineWidthScale: this.lineWidthScale }),
-      ...(this.lineWidthMinPixels && {
+      ...(this.diskResolution !== null && {
+        diskResolution: this.diskResolution,
+      }),
+      ...(this.radius !== null && { radius: this.radius }),
+      ...(this.angle !== null && { angle: this.angle }),
+      ...(this.vertices !== null &&
+        this.vertices !== undefined && { vertices: this.vertices }),
+      ...(this.offset !== null && { offset: this.offset }),
+      ...(this.coverage !== null && { coverage: this.coverage }),
+      ...(this.elevationScale !== null && {
+        elevationScale: this.elevationScale,
+      }),
+      ...(this.filled !== null && { filled: this.filled }),
+      ...(this.stroked !== null && { stroked: this.stroked }),
+      ...(this.extruded !== null && { extruded: this.extruded }),
+      ...(this.wireframe !== null && { wireframe: this.wireframe }),
+      ...(this.flatShading !== null && { flatShading: this.flatShading }),
+      ...(this.radiusUnits !== null && { radiusUnits: this.radiusUnits }),
+      ...(this.lineWidthUnits !== null && {
+        lineWidthUnits: this.lineWidthUnits,
+      }),
+      ...(this.lineWidthScale !== null && {
+        lineWidthScale: this.lineWidthScale,
+      }),
+      ...(this.lineWidthMinPixels !== null && {
         lineWidthMinPixels: this.lineWidthMinPixels,
       }),
-      ...(this.lineWidthMaxPixels && {
+      ...(this.lineWidthMaxPixels !== null && {
         lineWidthMaxPixels: this.lineWidthMaxPixels,
       }),
-      ...(this.material && { material: this.material }),
-      ...(this.getPosition && { getPosition: this.getPosition }),
-      ...(this.getFillColor && { getFillColor: this.getFillColor }),
-      ...(this.getLineColor && { getLineColor: this.getLineColor }),
-      ...(this.getElevation && { getElevation: this.getElevation }),
-      ...(this.getLineWidth && { getLineWidth: this.getLineWidth }),
+      ...(this.material !== null && { material: this.material }),
+      ...(this.getPosition !== null && { getPosition: this.getPosition }),
+      ...(this.getFillColor !== null && { getFillColor: this.getFillColor }),
+      ...(this.getLineColor !== null && { getLineColor: this.getLineColor }),
+      ...(this.getElevation !== null && { getElevation: this.getElevation }),
+      ...(this.getLineWidth !== null && { getLineWidth: this.getLineWidth }),
     };
   }
 
@@ -381,18 +408,20 @@ export class HeatmapModel extends BaseArrowLayerModel {
   layerProps(): Omit<GeoArrowHeatmapLayerProps, "id"> {
     return {
       data: this.table,
-      ...(this.radiusPixels && { radiusPixels: this.radiusPixels }),
-      ...(this.colorRange && { colorRange: this.colorRange }),
-      ...(this.intensity && { intensity: this.intensity }),
-      ...(this.threshold && { threshold: this.threshold }),
-      ...(this.colorDomain && { colorDomain: this.colorDomain }),
-      ...(this.aggregation && { aggregation: this.aggregation }),
-      ...(this.weightsTextureSize && {
+      ...(this.radiusPixels !== null && { radiusPixels: this.radiusPixels }),
+      ...(this.colorRange !== null && { colorRange: this.colorRange }),
+      ...(this.intensity !== null && { intensity: this.intensity }),
+      ...(this.threshold !== null && { threshold: this.threshold }),
+      ...(this.colorDomain !== null && { colorDomain: this.colorDomain }),
+      ...(this.aggregation !== null && { aggregation: this.aggregation }),
+      ...(this.weightsTextureSize !== null && {
         weightsTextureSize: this.weightsTextureSize,
       }),
-      ...(this.debounceTimeout && { debounceTimeout: this.debounceTimeout }),
-      ...(this.getPosition && { getPosition: this.getPosition }),
-      ...(this.getWeight && { getWeight: this.getWeight }),
+      ...(this.debounceTimeout !== null && {
+        debounceTimeout: this.debounceTimeout,
+      }),
+      ...(this.getPosition !== null && { getPosition: this.getPosition }),
+      ...(this.getWeight !== null && { getWeight: this.getWeight }),
     };
   }
 
@@ -437,16 +466,20 @@ export class PathModel extends BaseArrowLayerModel {
   layerProps(): Omit<GeoArrowPathLayerProps, "id"> {
     return {
       data: this.table,
-      ...(this.widthUnits && { widthUnits: this.widthUnits }),
-      ...(this.widthScale && { widthScale: this.widthScale }),
-      ...(this.widthMinPixels && { widthMinPixels: this.widthMinPixels }),
-      ...(this.widthMaxPixels && { widthMaxPixels: this.widthMaxPixels }),
-      ...(this.jointRounded && { jointRounded: this.jointRounded }),
-      ...(this.capRounded && { capRounded: this.capRounded }),
-      ...(this.miterLimit && { miterLimit: this.miterLimit }),
-      ...(this.billboard && { billboard: this.billboard }),
-      ...(this.getColor && { getColor: this.getColor }),
-      ...(this.getWidth && { getWidth: this.getWidth }),
+      ...(this.widthUnits !== null && { widthUnits: this.widthUnits }),
+      ...(this.widthScale !== null && { widthScale: this.widthScale }),
+      ...(this.widthMinPixels !== null && {
+        widthMinPixels: this.widthMinPixels,
+      }),
+      ...(this.widthMaxPixels !== null && {
+        widthMaxPixels: this.widthMaxPixels,
+      }),
+      ...(this.jointRounded !== null && { jointRounded: this.jointRounded }),
+      ...(this.capRounded !== null && { capRounded: this.capRounded }),
+      ...(this.miterLimit !== null && { miterLimit: this.miterLimit }),
+      ...(this.billboard !== null && { billboard: this.billboard }),
+      ...(this.getColor !== null && { getColor: this.getColor }),
+      ...(this.getWidth !== null && { getWidth: this.getWidth }),
     };
   }
 
@@ -512,28 +545,38 @@ export class ScatterplotModel extends BaseArrowLayerModel {
   }
 
   layerProps(): Omit<GeoArrowScatterplotLayerProps, "id"> {
+    console.log("stroked", this.stroked);
+
     return {
       data: this.table,
-      ...(this.radiusUnits && { radiusUnits: this.radiusUnits }),
-      ...(this.radiusScale && { radiusScale: this.radiusScale }),
-      ...(this.radiusMinPixels && { radiusMinPixels: this.radiusMinPixels }),
-      ...(this.radiusMaxPixels && { radiusMaxPixels: this.radiusMaxPixels }),
-      ...(this.lineWidthUnits && { lineWidthUnits: this.lineWidthUnits }),
-      ...(this.lineWidthScale && { lineWidthScale: this.lineWidthScale }),
-      ...(this.lineWidthMinPixels && {
+      ...(this.radiusUnits !== null && { radiusUnits: this.radiusUnits }),
+      ...(this.radiusScale !== null && { radiusScale: this.radiusScale }),
+      ...(this.radiusMinPixels !== null && {
+        radiusMinPixels: this.radiusMinPixels,
+      }),
+      ...(this.radiusMaxPixels !== null && {
+        radiusMaxPixels: this.radiusMaxPixels,
+      }),
+      ...(this.lineWidthUnits !== null && {
+        lineWidthUnits: this.lineWidthUnits,
+      }),
+      ...(this.lineWidthScale !== null && {
+        lineWidthScale: this.lineWidthScale,
+      }),
+      ...(this.lineWidthMinPixels !== null && {
         lineWidthMinPixels: this.lineWidthMinPixels,
       }),
-      ...(this.lineWidthMaxPixels && {
+      ...(this.lineWidthMaxPixels !== null && {
         lineWidthMaxPixels: this.lineWidthMaxPixels,
       }),
-      ...(this.stroked && { stroked: this.stroked }),
-      ...(this.filled && { filled: this.filled }),
-      ...(this.billboard && { billboard: this.billboard }),
-      ...(this.antialiasing && { antialiasing: this.antialiasing }),
-      ...(this.getRadius && { getRadius: this.getRadius }),
-      ...(this.getFillColor && { getFillColor: this.getFillColor }),
-      ...(this.getLineColor && { getLineColor: this.getLineColor }),
-      ...(this.getLineWidth && { getLineWidth: this.getLineWidth }),
+      ...(this.stroked !== null && { stroked: this.stroked }),
+      ...(this.filled !== null && { filled: this.filled }),
+      ...(this.billboard !== null && { billboard: this.billboard }),
+      ...(this.antialiasing !== null && { antialiasing: this.antialiasing }),
+      ...(this.getRadius !== null && { getRadius: this.getRadius }),
+      ...(this.getFillColor !== null && { getFillColor: this.getFillColor }),
+      ...(this.getLineColor !== null && { getLineColor: this.getLineColor }),
+      ...(this.getLineWidth !== null && { getLineWidth: this.getLineWidth }),
     };
   }
 
@@ -574,13 +617,15 @@ export class SolidPolygonModel extends BaseArrowLayerModel {
   layerProps(): Omit<GeoArrowSolidPolygonLayerProps, "id"> {
     return {
       data: this.table,
-      ...(this.filled && { filled: this.filled }),
-      ...(this.extruded && { extruded: this.extruded }),
-      ...(this.wireframe && { wireframe: this.wireframe }),
-      ...(this.elevationScale && { elevationScale: this.elevationScale }),
-      ...(this.getElevation && { getElevation: this.getElevation }),
-      ...(this.getFillColor && { getFillColor: this.getFillColor }),
-      ...(this.getLineColor && { getLineColor: this.getLineColor }),
+      ...(this.filled !== null && { filled: this.filled }),
+      ...(this.extruded !== null && { extruded: this.extruded }),
+      ...(this.wireframe !== null && { wireframe: this.wireframe }),
+      ...(this.elevationScale !== null && {
+        elevationScale: this.elevationScale,
+      }),
+      ...(this.getElevation !== null && { getElevation: this.getElevation }),
+      ...(this.getFillColor !== null && { getFillColor: this.getFillColor }),
+      ...(this.getLineColor !== null && { getLineColor: this.getLineColor }),
     };
   }
 
@@ -668,40 +713,47 @@ export class TextModel extends BaseArrowLayerModel {
   layerProps(): Omit<GeoArrowTextLayerProps, "id"> {
     return {
       data: this.table,
-      ...(this.billboard && { billboard: this.billboard }),
-      ...(this.sizeScale && { sizeScale: this.sizeScale }),
-      ...(this.sizeUnits && { sizeUnits: this.sizeUnits }),
-      ...(this.sizeMinPixels && { sizeMinPixels: this.sizeMinPixels }),
-      ...(this.sizeMaxPixels && { sizeMaxPixels: this.sizeMaxPixels }),
-      // ...(this.background && {background: this.background}),
-      ...(this.backgroundPadding && {
+      // Always provided
+      getText: this.getText,
+      ...(this.billboard !== null && { billboard: this.billboard }),
+      ...(this.sizeScale !== null && { sizeScale: this.sizeScale }),
+      ...(this.sizeUnits !== null && { sizeUnits: this.sizeUnits }),
+      ...(this.sizeMinPixels !== null && { sizeMinPixels: this.sizeMinPixels }),
+      ...(this.sizeMaxPixels !== null && { sizeMaxPixels: this.sizeMaxPixels }),
+      // ...(this.background !== null && {background: this.background}),
+      ...(this.backgroundPadding !== null && {
         backgroundPadding: this.backgroundPadding,
       }),
-      ...(this.characterSet && { characterSet: this.characterSet }),
-      ...(this.fontFamily && { fontFamily: this.fontFamily }),
-      ...(this.fontWeight && { fontWeight: this.fontWeight }),
-      ...(this.lineHeight && { lineHeight: this.lineHeight }),
-      ...(this.outlineWidth && { outlineWidth: this.outlineWidth }),
-      ...(this.outlineColor && { outlineColor: this.outlineColor }),
-      ...(this.fontSettings && { fontSettings: this.fontSettings }),
-      ...(this.wordBreak && { wordBreak: this.wordBreak }),
-      ...(this.maxWidth && { maxWidth: this.maxWidth }),
+      ...(this.characterSet !== null && { characterSet: this.characterSet }),
+      ...(this.fontFamily !== null && { fontFamily: this.fontFamily }),
+      ...(this.fontWeight !== null && { fontWeight: this.fontWeight }),
+      ...(this.lineHeight !== null && { lineHeight: this.lineHeight }),
+      ...(this.outlineWidth !== null && { outlineWidth: this.outlineWidth }),
+      ...(this.outlineColor !== null && { outlineColor: this.outlineColor }),
+      ...(this.fontSettings !== null && { fontSettings: this.fontSettings }),
+      ...(this.wordBreak !== null && { wordBreak: this.wordBreak }),
+      ...(this.maxWidth !== null && { maxWidth: this.maxWidth }),
 
-      ...(this.getBackgroundColor && {
+      ...(this.getBackgroundColor !== null && {
         getBackgroundColor: this.getBackgroundColor,
       }),
-      ...(this.getBorderColor && { getBorderColor: this.getBorderColor }),
-      ...(this.getBorderWidth && { getBorderWidth: this.getBorderWidth }),
-      ...(this.getText && { getText: this.getText }),
-      ...(this.getPosition && { getPosition: this.getPosition }),
-      ...(this.getColor && { getColor: this.getColor }),
-      ...(this.getSize && { getSize: this.getSize }),
-      ...(this.getAngle && { getAngle: this.getAngle }),
-      ...(this.getTextAnchor && { getTextAnchor: this.getTextAnchor }),
-      ...(this.getAlignmentBaseline && {
+      ...(this.getBorderColor !== null && {
+        getBorderColor: this.getBorderColor,
+      }),
+      ...(this.getBorderWidth !== null && {
+        getBorderWidth: this.getBorderWidth,
+      }),
+      ...(this.getPosition !== null && { getPosition: this.getPosition }),
+      ...(this.getColor !== null && { getColor: this.getColor }),
+      ...(this.getSize !== null && { getSize: this.getSize }),
+      ...(this.getAngle !== null && { getAngle: this.getAngle }),
+      ...(this.getTextAnchor !== null && { getTextAnchor: this.getTextAnchor }),
+      ...(this.getAlignmentBaseline !== null && {
         getAlignmentBaseline: this.getAlignmentBaseline,
       }),
-      ...(this.getPixelOffset && { getPixelOffset: this.getPixelOffset }),
+      ...(this.getPixelOffset !== null && {
+        getPixelOffset: this.getPixelOffset,
+      }),
     };
   }
 


### PR DESCRIPTION
Previously we had never been passing on falsy values to the deck.gl layer. Now, we try to be more consistent about initializing values to `None`, which get converted to `null` on the JS side. Then we check explicitly for `null` before passing values to deck layers.

Closes https://github.com/developmentseed/lonboard/issues/274