### PR TITLE
Move accessor length validation to serialization

### DIFF
--- a/lonboard/_layer.py
+++ b/lonboard/_layer.py
@@ -763,16 +763,6 @@ class ScatterplotLayer(BaseArrowLayer):
     - Default: `1`.
     """
 
-    @traitlets.validate(
-        "get_radius", "get_fill_color", "get_line_color", "get_line_width"
-    )
-    def _validate_accessor_length(self, proposal):
-        if isinstance(proposal["value"], (pa.ChunkedArray, pa.Array)):
-            if len(proposal["value"]) != len(self.table):
-                raise traitlets.TraitError("accessor must have same length as table")
-
-        return proposal["value"]
-
 
 class PathLayer(BaseArrowLayer):
     """
@@ -926,14 +916,6 @@ class PathLayer(BaseArrowLayer):
     - Default: `1`.
     """
 
-    @traitlets.validate("get_color", "get_width")
-    def _validate_accessor_length(self, proposal):
-        if isinstance(proposal["value"], (pa.ChunkedArray, pa.Array)):
-            if len(proposal["value"]) != len(self.table):
-                raise traitlets.TraitError("accessor must have same length as table")
-
-        return proposal["value"]
-
 
 class SolidPolygonLayer(BaseArrowLayer):
     """
@@ -1074,14 +1056,6 @@ class SolidPolygonLayer(BaseArrowLayer):
     - Default: `[0, 0, 0, 255]`.
     """
 
-    @traitlets.validate("get_elevation", "get_fill_color", "get_line_color")
-    def _validate_accessor_length(self, proposal):
-        if isinstance(proposal["value"], (pa.ChunkedArray, pa.Array)):
-            if len(proposal["value"]) != len(self.table):
-                raise traitlets.TraitError("accessor must have same length as table")
-
-        return proposal["value"]
-
 
 class HeatmapLayer(BaseArrowLayer):
     """The `HeatmapLayer` visualizes the spatial distribution of data.
@@ -1214,11 +1188,3 @@ class HeatmapLayer(BaseArrowLayer):
           width for the object at the same row index.
     - Default: `1`.
     """
-
-    @traitlets.validate("get_weight")
-    def _validate_accessor_length(self, proposal):
-        if isinstance(proposal["value"], (pa.ChunkedArray, pa.Array)):
-            if len(proposal["value"]) != len(self.table):
-                raise traitlets.TraitError("accessor must have same length as table")
-
-        return proposal["value"]

--- a/lonboard/experimental/_layer.py
+++ b/lonboard/experimental/_layer.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import pyarrow as pa
 import traitlets
 
 from lonboard._constants import EXTENSION_NAME
@@ -122,22 +121,6 @@ class ArcLayer(BaseArrowLayer):
           the path at the same row index.
     - Default: `0`.
     """
-
-    @traitlets.validate(
-        "get_source_position",
-        "get_target_position",
-        "get_source_color",
-        "get_target_color",
-        "get_width",
-        "get_height",
-        "get_tilt",
-    )
-    def _validate_accessor_length(self, proposal):
-        if isinstance(proposal["value"], (pa.ChunkedArray, pa.Array)):
-            if len(proposal["value"]) != len(self.table):
-                raise traitlets.TraitError("accessor must have same length as table")
-
-        return proposal["value"]
 
 
 class TextLayer(BaseArrowLayer):

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -5,6 +5,7 @@ import shapely
 from traitlets import TraitError
 
 from lonboard import ScatterplotLayer
+from lonboard.experimental import DataFilterExtension
 
 
 def test_accessor_length_validation():
@@ -19,6 +20,27 @@ def test_accessor_length_validation():
         _layer = ScatterplotLayer.from_geopandas(gdf, get_radius=np.array([1, 2, 3]))
 
     _layer = ScatterplotLayer.from_geopandas(gdf, get_radius=np.array([1, 2]))
+
+
+def test_accessor_length_validation_extension():
+    """Accessor length must match table length"""
+    points = shapely.points([1, 2], [3, 4])
+    gdf = gpd.GeoDataFrame(geometry=points)
+    extension = DataFilterExtension()
+
+    with pytest.raises(TraitError, match="same length as table"):
+        _layer = ScatterplotLayer.from_geopandas(
+            gdf, extensions=[extension], get_filter_value=np.array([1])
+        )
+
+    with pytest.raises(TraitError, match="same length as table"):
+        _layer = ScatterplotLayer.from_geopandas(
+            gdf, extensions=[extension], get_filter_value=np.array([1, 2, 3])
+        )
+
+    _layer = ScatterplotLayer.from_geopandas(
+        gdf, extensions=[extension], get_radius=np.array([1, 2])
+    )
 
 
 def test_layer_fails_with_unexpected_argument():

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -10,6 +10,9 @@ from lonboard.traits import ColorAccessor, FloatAccessor
 
 class ColorAccessorWidget(BaseLayer):
     _rows_per_chunk = 2
+    # Any tests that are intended to pass validation checks must also have 3 rows, since
+    # there's another length check in the serialization code.
+    table = pa.table({"data": [1, 2, 3]})
 
     color = ColorAccessor()
 
@@ -65,8 +68,12 @@ def test_color_accessor_validation_dim_shape_np_arr():
             color=np.array([1, 2, 3, 4, 5], dtype=np.uint8).reshape(-1, 5)
         )
 
-    ColorAccessorWidget(color=np.array([1, 2, 3], dtype=np.uint8).reshape(-1, 3))
-    ColorAccessorWidget(color=np.array([1, 2, 3, 255], dtype=np.uint8).reshape(-1, 4))
+    ColorAccessorWidget(
+        color=np.array([1, 2, 3], dtype=np.uint8).reshape(-1, 3).repeat(3, axis=0)
+    )
+    ColorAccessorWidget(
+        color=np.array([1, 2, 3, 255], dtype=np.uint8).reshape(-1, 4).repeat(3, axis=0)
+    )
 
 
 def test_color_accessor_validation_np_dtype():
@@ -74,7 +81,9 @@ def test_color_accessor_validation_np_dtype():
     with pytest.raises(TraitError):
         ColorAccessorWidget(color=np.array([1, 2, 3]).reshape(-1, 3))
 
-    ColorAccessorWidget(color=np.array([1, 2, 3], dtype=np.uint8).reshape(-1, 3))
+    ColorAccessorWidget(
+        color=np.array([1, 2, 3], dtype=np.uint8).reshape(-1, 3).repeat(3, axis=0)
+    )
 
 
 def test_color_accessor_validation_pyarrow_array_type():
@@ -82,10 +91,10 @@ def test_color_accessor_validation_pyarrow_array_type():
     with pytest.raises(TraitError):
         ColorAccessorWidget(color=pa.array(np.array([1, 2, 3], dtype=np.float64)))
 
-    np_arr = np.array([1, 2, 3], dtype=np.uint8)
+    np_arr = np.array([1, 2, 3], dtype=np.uint8).repeat(3, axis=0)
     ColorAccessorWidget(color=pa.FixedSizeListArray.from_arrays(np_arr, 3))
 
-    np_arr = np.array([1, 2, 3, 255], dtype=np.uint8)
+    np_arr = np.array([1, 2, 3, 255], dtype=np.uint8).repeat(3, axis=0)
     ColorAccessorWidget(color=pa.FixedSizeListArray.from_arrays(np_arr, 4))
 
     # array type must have uint8 child
@@ -117,6 +126,9 @@ def test_color_accessor_validation_string():
 
 class FloatAccessorWidget(BaseLayer):
     _rows_per_chunk = 2
+    # Any tests that are intended to pass validation checks must also have 3 rows, since
+    # there's another length check in the serialization code.
+    table = pa.table({"data": [1, 2, 3]})
 
     value = FloatAccessor()
 


### PR DESCRIPTION
Closes https://github.com/developmentseed/lonboard/issues/329

Currently we validate accessor length in `_validate_accessor_length` on the layer itself, but that's probably not able to dynamically validate all accessors, even those added by an extension. Instead, we can check during serialization that the length of the column is the same as the length of the table.

This additionally adds a test that accessor length validation is checked for extension accessors