### PR TITLE
Deduplicate serialization for accessors

### DIFF
--- a/lonboard/experimental/traits.py
+++ b/lonboard/experimental/traits.py
@@ -7,9 +7,7 @@ import numpy as np
 import pyarrow as pa
 from traitlets.traitlets import TraitType
 
-from lonboard._serialization import (
-    COLOR_SERIALIZATION,
-)
+from lonboard._serialization import ACCESSOR_SERIALIZATION
 from lonboard.traits import FixedErrorTraitType
 
 
@@ -39,7 +37,7 @@ class PointAccessor(FixedErrorTraitType):
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
-        self.tag(sync=True, **COLOR_SERIALIZATION)
+        self.tag(sync=True, **ACCESSOR_SERIALIZATION)
 
     def validate(
         self, obj, value

--- a/lonboard/traits.py
+++ b/lonboard/traits.py
@@ -18,8 +18,7 @@ from traitlets.utils.descriptions import class_of, describe
 from typing_extensions import Self
 
 from lonboard._serialization import (
-    COLOR_SERIALIZATION,
-    FLOAT_SERIALIZATION,
+    ACCESSOR_SERIALIZATION,
     TABLE_SERIALIZATION,
 )
 
@@ -206,7 +205,7 @@ class ColorAccessor(FixedErrorTraitType):
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
-        self.tag(sync=True, **COLOR_SERIALIZATION)
+        self.tag(sync=True, **ACCESSOR_SERIALIZATION)
 
     def validate(
         self, obj, value
@@ -332,7 +331,7 @@ class FloatAccessor(FixedErrorTraitType):
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
-        self.tag(sync=True, **FLOAT_SERIALIZATION)
+        self.tag(sync=True, **ACCESSOR_SERIALIZATION)
 
     def validate(self, obj, value) -> Union[float, pa.ChunkedArray, pa.DoubleArray]:
         if isinstance(value, (int, float)):
@@ -402,7 +401,7 @@ class TextAccessor(FixedErrorTraitType):
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
-        self.tag(sync=True, **FLOAT_SERIALIZATION)
+        self.tag(sync=True, **ACCESSOR_SERIALIZATION)
 
     def validate(self, obj, value) -> Union[float, pa.ChunkedArray, pa.DoubleArray]:
         if isinstance(value, str):


### PR DESCRIPTION
Previously, we had two copies of serialization that were doing essentially the same thing. 

This deduplicates accessor serialization to allow any "json-serializable" value through (a superset technically; whatever ipywidgets default serialization supports) but then otherwise assume the input is a pyarrow column and serialize that to a parquet file.