### PR TITLE
geoarrow-based multithreaded coordinate reprojection

### DIFF
--- a/lonboard/_geoarrow/geopandas_interop.py
+++ b/lonboard/_geoarrow/geopandas_interop.py
@@ -18,5 +18,8 @@ def geopandas_to_geoarrow(
         df_attr = df_attr[columns]
 
     table = pa.Table.from_pandas(df_attr, preserve_index=preserve_index)
-    field, geom_arr = construct_geometry_array(np.array(gdf.geometry))
+    field, geom_arr = construct_geometry_array(
+        np.array(gdf.geometry), crs_str=gdf.crs.to_json()
+    )
+
     return table.append_column(field, geom_arr)

--- a/lonboard/_geoarrow/geopandas_interop.py
+++ b/lonboard/_geoarrow/geopandas_interop.py
@@ -19,7 +19,8 @@ def geopandas_to_geoarrow(
 
     table = pa.Table.from_pandas(df_attr, preserve_index=preserve_index)
     field, geom_arr = construct_geometry_array(
-        np.array(gdf.geometry), crs_str=gdf.crs.to_json()
+        np.array(gdf.geometry),
+        crs_str=gdf.crs.to_json() if gdf.crs is not None else None,
     )
 
     return table.append_column(field, geom_arr)

--- a/lonboard/_geoarrow/ops/__init__.py
+++ b/lonboard/_geoarrow/ops/__init__.py
@@ -3,4 +3,4 @@
 
 from .bbox import total_bounds
 from .centroid import weighted_centroid
-from .reproject import reproject
+from .reproject import reproject_column, reproject_table

--- a/lonboard/_geoarrow/ops/__init__.py
+++ b/lonboard/_geoarrow/ops/__init__.py
@@ -3,3 +3,4 @@
 
 from .bbox import total_bounds
 from .centroid import weighted_centroid
+from .reproject import reproject

--- a/lonboard/_geoarrow/ops/reproject.py
+++ b/lonboard/_geoarrow/ops/reproject.py
@@ -1,0 +1,172 @@
+"""Reproject a GeoArrow array
+"""
+import json
+from concurrent.futures import ThreadPoolExecutor
+from functools import lru_cache, partial
+from typing import Callable, Optional, Tuple, Union
+
+import numpy as np
+import pyarrow as pa
+from pyproj import CRS, Transformer
+
+from lonboard._constants import EXTENSION_NAME, OGC_84
+from lonboard._geoarrow.extension_types import CoordinateDimension
+
+TransformerFromCRS = lru_cache(Transformer.from_crs)
+
+
+def reproject(
+    field: pa.Field,
+    column: pa.ChunkedArray,
+    to_crs: Union[str, CRS] = OGC_84,
+    *,
+    max_workers: Optional[int] = None,
+) -> Tuple[pa.Field, pa.ChunkedArray]:
+    """Reproject a GeoArrow array to a new CRS
+
+    Args:
+        field: The field describing the column
+        column: A ChunkedArray
+        to_crs: The target CRS. Defaults to OGC_84.
+        max_workers: The maximum number of threads to use. Defaults to None.
+    """
+    extension_type_name = field.metadata[b"ARROW:extension:name"]
+    extension_metadata = json.loads(field.metadata[b"ARROW:extension:metadata"])
+    crs_str = extension_metadata["crs"]
+    existing_crs = CRS(crs_str)
+
+    if existing_crs.is_exact_same(to_crs):
+        return field, column
+
+    transformer = TransformerFromCRS(existing_crs, to_crs, always_xy=True)
+
+    # Metadata inside metadata, bad naming
+    new_extension_meta_meta = {"crs": CRS(to_crs).to_json()}
+    new_extension_metadata = {
+        b"ARROW:extension:name": extension_type_name,
+        b"ARROW:extension:metadata": json.dumps(new_extension_meta_meta),
+    }
+
+    new_chunked_array = _reproject_column(
+        column,
+        extension_type_name=extension_type_name,
+        transformer=transformer,
+        max_workers=max_workers,
+    )
+    return field.with_metadata(new_extension_metadata), new_chunked_array
+
+
+def _reproject_column(
+    column: pa.ChunkedArray,
+    *,
+    extension_type_name: EXTENSION_NAME,
+    transformer: Transformer,
+    max_workers: Optional[int] = None,
+) -> pa.ChunkedArray:
+    if extension_type_name == EXTENSION_NAME.POINT:
+        func = partial(_reproject_chunk_nest_0, transformer=transformer)
+    elif extension_type_name in [EXTENSION_NAME.LINESTRING, EXTENSION_NAME.MULTIPOINT]:
+        func = partial(_reproject_chunk_nest_1, transformer=transformer)
+    elif extension_type_name in [
+        EXTENSION_NAME.POLYGON,
+        EXTENSION_NAME.MULTILINESTRING,
+    ]:
+        func = partial(_reproject_chunk_nest_2, transformer=transformer)
+
+    elif extension_type_name == EXTENSION_NAME.MULTIPOLYGON:
+        func = partial(_reproject_chunk_nest_3, transformer=transformer)
+    else:
+        raise ValueError(f"Unexpected extension type name {extension_type_name}")
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        return pa.chunked_array(executor.map(func, column.chunks))
+
+
+def _reproject_coords(arr: pa.FixedSizeListArray, transformer: Transformer):
+    list_size = arr.type.list_size
+    np_arr = arr.flatten().to_numpy().reshape(-1, list_size)
+
+    if list_size == 2:
+        output_np_arr = np.column_stack(
+            transformer.transform(np_arr[:, 0], np_arr[:, 1])
+        )
+        dims = CoordinateDimension.XY
+    elif list_size == 3:
+        output_np_arr = np.column_stack(
+            transformer.transform(np_arr[:, 0], np_arr[:, 1], np_arr[:, 2])
+        )
+        dims = CoordinateDimension.XYZ
+    else:
+        raise ValueError(f"Unexpected list size {list_size}")
+
+    coord_field = pa.list_(pa.field(dims, pa.float64()), len(dims))
+    return pa.FixedSizeListArray.from_arrays(
+        output_np_arr.flatten("C"), type=coord_field
+    )
+
+
+def _reproject_chunk_nest_0(arr: pa.ListArray, transformer: Transformer):
+    callback = partial(_reproject_coords, transformer=transformer)
+    return _map_coords_nest_0(arr, callback)
+
+
+def _reproject_chunk_nest_1(arr: pa.ListArray, transformer: Transformer):
+    callback = partial(_reproject_coords, transformer=transformer)
+    return _map_coords_nest_1(arr, callback)
+
+
+def _reproject_chunk_nest_2(arr: pa.ListArray, transformer: Transformer):
+    callback = partial(_reproject_coords, transformer=transformer)
+    return _map_coords_nest_2(arr, callback)
+
+
+def _reproject_chunk_nest_3(arr: pa.ListArray, transformer: Transformer):
+    callback = partial(_reproject_coords, transformer=transformer)
+    return _map_coords_nest_3(arr, callback)
+
+
+def _map_coords_nest_0(
+    arr: pa.FixedSizeListArray,
+    callback: Callable[[pa.FixedSizeListArray], pa.FixedSizeListArray],
+):
+    new_coords = callback(arr)
+    return new_coords
+
+
+def _map_coords_nest_1(
+    arr: pa.ListArray,
+    callback: Callable[[pa.FixedSizeListArray], pa.FixedSizeListArray],
+):
+    geom_offsets = arr.offsets
+    coords = arr.flatten()
+    new_coords = callback(coords)
+    new_geometry_array = pa.ListArray.from_arrays(geom_offsets, new_coords)
+    return new_geometry_array
+
+
+def _map_coords_nest_2(
+    arr: pa.ListArray,
+    callback: Callable[[pa.FixedSizeListArray], pa.FixedSizeListArray],
+):
+    geom_offsets = arr.offsets
+    ring_offsets = arr.flatten().offsets
+    coords = arr.flatten().flatten()
+    new_coords = callback(coords)
+    new_ring_array = pa.ListArray.from_arrays(ring_offsets, new_coords)
+    new_geometry_array = pa.ListArray.from_arrays(geom_offsets, new_ring_array)
+    return new_geometry_array
+
+
+def _map_coords_nest_3(
+    arr: pa.ListArray,
+    callback: Callable[[pa.FixedSizeListArray], pa.FixedSizeListArray],
+):
+    geom_offsets = arr.offsets
+    polygon_offsets = arr.flatten().offsets
+    ring_offsets = arr.flatten().flatten().offsets
+    coords = arr.flatten().flatten().flatten()
+    new_coords = callback(coords)
+    new_ring_array = pa.ListArray.from_arrays(ring_offsets, new_coords)
+    new_polygon_array = pa.ListArray.from_arrays(polygon_offsets, new_ring_array)
+    new_geometry_array = pa.ListArray.from_arrays(geom_offsets, new_polygon_array)
+    return new_geometry_array

--- a/lonboard/_geoarrow/ops/reproject.py
+++ b/lonboard/_geoarrow/ops/reproject.py
@@ -34,11 +34,16 @@ def reproject_table(
         A new table.
     """
     geom_col_idx = get_geometry_column_index(table.schema)
+    # No geometry column in table
     if geom_col_idx is None:
         return table
 
     geom_field = table.schema.field(geom_col_idx)
     geom_column = table.column(geom_col_idx)
+
+    # geometry column exists in table but is not assigned a CRS
+    if b"ARROW:extension:metadata" not in geom_field.metadata:
+        return table
 
     new_field, new_column = reproject_column(
         field=geom_field, column=geom_column, to_crs=to_crs, max_workers=max_workers

--- a/lonboard/_geoarrow/ops/reproject.py
+++ b/lonboard/_geoarrow/ops/reproject.py
@@ -71,7 +71,7 @@ def reproject_column(
     crs_str = extension_metadata["crs"]
     existing_crs = CRS(crs_str)
 
-    if existing_crs.is_exact_same(to_crs):
+    if existing_crs == to_crs:
         return field, column
 
     # NOTE: Not sure the best place to put this warning

--- a/lonboard/_layer.py
+++ b/lonboard/_layer.py
@@ -231,13 +231,14 @@ class BaseArrowLayer(BaseLayer):
     def __init__(
         self, *, table: pa.Table, _rows_per_chunk: Optional[int] = None, **kwargs
     ):
+        # Reproject table to WGS84 if needed
+        # Note this must happen before calculating the default viewport
+        table = reproject_table(table, to_crs=OGC_84)
+
         default_viewport = default_geoarrow_viewport(table)
         if default_viewport is not None:
             self._bbox = default_viewport[0]
             self._weighted_centroid = default_viewport[1]
-
-        # Reproject table to WGS84 if needed
-        table = reproject_table(table, to_crs=OGC_84)
 
         rows_per_chunk = _rows_per_chunk or infer_rows_per_chunk(table)
         if rows_per_chunk <= 0:

--- a/lonboard/_layer.py
+++ b/lonboard/_layer.py
@@ -10,7 +10,6 @@
 from __future__ import annotations
 
 import sys
-import warnings
 from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple
 
 import geopandas as gpd
@@ -19,8 +18,9 @@ import pyarrow as pa
 import traitlets
 
 from lonboard._base import BaseExtension, BaseWidget
-from lonboard._constants import EPSG_4326, EXTENSION_NAME, OGC_84
+from lonboard._constants import EXTENSION_NAME, OGC_84
 from lonboard._geoarrow.geopandas_interop import geopandas_to_geoarrow
+from lonboard._geoarrow.ops import reproject_table
 from lonboard._geoarrow.ops.bbox import Bbox, total_bounds
 from lonboard._geoarrow.ops.centroid import WeightedCentroid, weighted_centroid
 from lonboard._serialization import infer_rows_per_chunk
@@ -182,9 +182,8 @@ def default_geoarrow_viewport(
 ) -> Optional[Tuple[Bbox, WeightedCentroid]]:
     # Note: in the ArcLayer we won't necessarily have a column with a geoarrow
     # extension type/metadata
-    try:
-        geom_col_idx = get_geometry_column_index(table.schema)
-    except ValueError:
+    geom_col_idx = get_geometry_column_index(table.schema)
+    if geom_col_idx is None:
         return None
 
     geom_field = table.schema.field(geom_col_idx)
@@ -237,6 +236,9 @@ class BaseArrowLayer(BaseLayer):
             self._bbox = default_viewport[0]
             self._weighted_centroid = default_viewport[1]
 
+        # Reproject table to WGS84 if needed
+        table = reproject_table(table, to_crs=OGC_84)
+
         rows_per_chunk = _rows_per_chunk or infer_rows_per_chunk(table)
         if rows_per_chunk <= 0:
             raise ValueError("Cannot serialize table with 0 rows per chunk.")
@@ -266,10 +268,6 @@ class BaseArrowLayer(BaseLayer):
         Returns:
             A Layer with the initialized data.
         """
-        if gdf.crs and gdf.crs not in [EPSG_4326, OGC_84]:
-            warnings.warn("GeoDataFrame being reprojected to EPSG:4326")
-            gdf = gdf.to_crs(OGC_84)  # type: ignore
-
         if auto_downcast:
             # Note: we don't deep copy because we don't need to clone geometries
             gdf = _auto_downcast(gdf.copy())  # type: ignore

--- a/lonboard/_utils.py
+++ b/lonboard/_utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Sequence, TypeVar
+from typing import Any, Dict, Optional, Sequence, TypeVar
 
 import numpy as np
 import pandas as pd
@@ -12,7 +12,7 @@ DF = TypeVar("DF", bound=pd.DataFrame)
 GEOARROW_EXTENSION_TYPE_NAMES = {e.value for e in EXTENSION_NAME}
 
 
-def get_geometry_column_index(schema: pa.Schema) -> int:
+def get_geometry_column_index(schema: pa.Schema) -> Optional[int]:
     """Get the positional index of the geometry column in a pyarrow Schema"""
     for field_idx in range(len(schema)):
         field_metadata = schema.field(field_idx).metadata
@@ -23,7 +23,7 @@ def get_geometry_column_index(schema: pa.Schema) -> int:
         ):
             return field_idx
 
-    raise ValueError("No geometry column in table schema.")
+    return None
 
 
 def auto_downcast(df: DF) -> DF:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1020,6 +1020,20 @@ files = [
 ]
 
 [[package]]
+name = "geodatasets"
+version = "2023.12.0"
+description = "Spatial data examples"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "geodatasets-2023.12.0-py3-none-any.whl", hash = "sha256:6abf6dc2b5ec930465b19c33a1ba4211bf8aebbd544495ae9a5e81d9ca3ca294"},
+    {file = "geodatasets-2023.12.0.tar.gz", hash = "sha256:8867fa6966aeae3fe854697c9fb7d429666ae7ae8edda9b77c87c8e616ba6c65"},
+]
+
+[package.dependencies]
+pooch = "*"
+
+[[package]]
 name = "geopandas"
 version = "0.13.2"
 description = "Geographic pandas extensions"
@@ -2375,8 +2389,8 @@ files = [
 [package.dependencies]
 numpy = [
     {version = ">=1.20.3", markers = "python_version < \"3.10\""},
-    {version = ">=1.21.0", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
     {version = ">=1.23.2", markers = "python_version >= \"3.11\""},
+    {version = ">=1.21.0", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -2586,6 +2600,27 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "pooch"
+version = "1.8.0"
+description = "\"Pooch manages your Python library's sample data files: it automatically downloads and stores them in a local directory, with support for versioning and corruption checks.\""
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pooch-1.8.0-py3-none-any.whl", hash = "sha256:1bfba436d9e2ad5199ccad3583cca8c241b8736b5bb23fe67c213d52650dbb66"},
+    {file = "pooch-1.8.0.tar.gz", hash = "sha256:f59981fd5b9b5d032dcde8f4a11eaa492c2ac6343fae3596a2fdae35fc54b0a0"},
+]
+
+[package.dependencies]
+packaging = ">=20.0"
+platformdirs = ">=2.5.0"
+requests = ">=2.19.0"
+
+[package.extras]
+progress = ["tqdm (>=4.41.0,<5.0.0)"]
+sftp = ["paramiko (>=2.7.0)"]
+xxhash = ["xxhash (>=1.4.3)"]
 
 [[package]]
 name = "pre-commit"
@@ -2824,6 +2859,51 @@ pyyaml = "*"
 
 [package.extras]
 extra = ["pygments (>=2.12)"]
+
+[[package]]
+name = "pyogrio"
+version = "0.7.2"
+description = "Vectorized spatial vector file format I/O using GDAL/OGR"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pyogrio-0.7.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ba386a02c9b5934c568b40acc95c9863f92075f6990167635e51368976569c66"},
+    {file = "pyogrio-0.7.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:860b04ddf23b8c253ceb3621e4b0e0dc0f293eab66cb14f799a5c9f9fe0a882c"},
+    {file = "pyogrio-0.7.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:caaf61d473ac207f170082e602ea57c096e8dd4c4be51de58fba96f1a5944096"},
+    {file = "pyogrio-0.7.2-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:bee556ca305b7e8c68aada259d925c612131205074fb2373badafacbef610b77"},
+    {file = "pyogrio-0.7.2-cp310-cp310-win_amd64.whl", hash = "sha256:7e2c856961efdc6cb3809b97b49016cbbcee17c8a1e85fc4000b5fcb3cfcb9b1"},
+    {file = "pyogrio-0.7.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5654e7c33442cbd98e7a56f705e160415d7503b2420d724d4f81b8cc88360b3e"},
+    {file = "pyogrio-0.7.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b9a8a4854c7af2c76683ce5666ee765b207901b362576465219d75deb6159821"},
+    {file = "pyogrio-0.7.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a23136d1bffa9d811263807b850c6e9854201710276f09de650131e89f2486aa"},
+    {file = "pyogrio-0.7.2-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:234b0d1d22e9680229b0618c25077a0cb2428cbbc2939b4bb9bdd8ee77e0f3e0"},
+    {file = "pyogrio-0.7.2-cp311-cp311-win_amd64.whl", hash = "sha256:33ae5aafcf3a557e107a33f5b3e878750d2e467b8cc911dc4bf261c1a602b534"},
+    {file = "pyogrio-0.7.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:73577fecebeecf0d06e78c1a4bddd460a4d57c6d918affab7594c0bc72f5fa14"},
+    {file = "pyogrio-0.7.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f2ff58184020da39540a2f5d4a5412005a01b0c4cd03c7b8294bc670d1f3fe50"},
+    {file = "pyogrio-0.7.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:31112bb0b6a4a3f80ec3252d7eeb7be81045860d49fd76e297c073759450652b"},
+    {file = "pyogrio-0.7.2-cp312-cp312-win_amd64.whl", hash = "sha256:1b7197c72f034ac7187da2a8d50a063a5f1256aab732b154f11f887a7652dc3d"},
+    {file = "pyogrio-0.7.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7e39bb6bfdd74e63ae96acced7297bbe8a157f85c0107f1cbb395d2a937f3a38"},
+    {file = "pyogrio-0.7.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:436de39f57e8f8cc41682981518b9490d64d3a1c48bf78d415e5747c296790dc"},
+    {file = "pyogrio-0.7.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5feeb7a0da7ee82580f6aa6508a80602413675b99c60c822929e0e8b925e0517"},
+    {file = "pyogrio-0.7.2-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:429dcff4c36f0e0a15ba4a20f2d4478b9c6d095e70c4bcc007a536ea420a1a93"},
+    {file = "pyogrio-0.7.2-cp38-cp38-win_amd64.whl", hash = "sha256:f219c1edb010d0248891a3d27d15faf17c91cfe69daef84d7471e22e4ed4fcff"},
+    {file = "pyogrio-0.7.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9cc6db2e5dc50dfe23554d10502920eafa0648c365725e552aaa523432a9bf35"},
+    {file = "pyogrio-0.7.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:be46be43c4148a3ad09da38670411485ec544a51cbd6b7d004a0eca5035023fc"},
+    {file = "pyogrio-0.7.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3001efd5dfee36459d0cfdafbe91ed88fc5ae734353d771cdb75546ef1427735"},
+    {file = "pyogrio-0.7.2-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:892fdab0e1c44c0125254d92928081c14f93ac553f371addc2c9a1d4bde41cad"},
+    {file = "pyogrio-0.7.2-cp39-cp39-win_amd64.whl", hash = "sha256:d5fc2304aeb927564f77caaa4da9a47e2d77a8ceb1c624ea84c505140886b221"},
+    {file = "pyogrio-0.7.2.tar.gz", hash = "sha256:33afb7d211c6434613f24174722347a5cb11d22a212f28c817f67c89d30d0c0d"},
+]
+
+[package.dependencies]
+certifi = "*"
+numpy = "*"
+packaging = "*"
+
+[package.extras]
+benchmark = ["pytest-benchmark"]
+dev = ["Cython"]
+geopandas = ["geopandas"]
+test = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "pyparsing"
@@ -3973,4 +4053,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "858df8237eae70012ec8d588ca594ea3a6de20dd308a0ffdf13ffdf893381a83"
+content-hash = "d2fdd606f82bdd939406f154df928c9c9f208804508dee26a76ba9b8dfe63409"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ pytest = "^7.4.2"
 # to format signatures in the docs
 black = "^23.10.1"
 geoarrow-rust-core = "^0.1.0"
+geodatasets = "^2023.12.0"
+pyogrio = "^0.7.2"
 
 [tool.poetry.group.docs.dependencies]
 mkdocs = "^1.4.3"

--- a/tests/test_geoarrow.py
+++ b/tests/test_geoarrow.py
@@ -1,0 +1,53 @@
+import json
+
+import geodatasets
+import geopandas as gpd
+from pyproj import CRS
+
+from lonboard import SolidPolygonLayer
+from lonboard._constants import OGC_84
+from lonboard._geoarrow.geopandas_interop import geopandas_to_geoarrow
+from lonboard._utils import get_geometry_column_index
+
+
+def test_geopandas_table_reprojection():
+    gdf = gpd.read_file(geodatasets.get_path("nybb"))
+    layer = SolidPolygonLayer.from_geopandas(gdf)
+
+    layer_geom_col_idx = get_geometry_column_index(layer.table.schema)
+    layer_geom_field = layer.table.schema.field(layer_geom_col_idx)
+
+    reprojected_crs_str = json.loads(
+        layer_geom_field.metadata[b"ARROW:extension:metadata"]
+    )["crs"]
+    assert OGC_84 == CRS.from_json(
+        reprojected_crs_str
+    ), "layer should be reprojected to WGS84"
+
+
+def test_geoarrow_table_reprojection():
+    gdf = gpd.read_file(geodatasets.get_path("nybb"))
+    table = geopandas_to_geoarrow(gdf)
+
+    geom_col_idx = get_geometry_column_index(table.schema)
+    assert geom_col_idx is not None, "geom column should exist"
+
+    geom_field = table.schema.field(geom_col_idx)
+    assert (
+        b"ARROW:extension:metadata" in geom_field.metadata
+    ), "Metadata key should exist"
+
+    crs_str = json.loads(geom_field.metadata[b"ARROW:extension:metadata"])["crs"]
+    assert gdf.crs == CRS.from_json(crs_str), "round trip crs should match gdf crs"
+
+    layer = SolidPolygonLayer(table=table)
+
+    layer_geom_col_idx = get_geometry_column_index(layer.table.schema)
+    layer_geom_field = layer.table.schema.field(layer_geom_col_idx)
+
+    reprojected_crs_str = json.loads(
+        layer_geom_field.metadata[b"ARROW:extension:metadata"]
+    )["crs"]
+    assert OGC_84 == CRS.from_json(
+        reprojected_crs_str
+    ), "layer should be reprojected to WGS84"


### PR DESCRIPTION
### Change list

- Include PROJJSON CRS on geometry array metadata when converting from GeoPandas
- Move CRS checking and reprojection into GeoArrow level instead of GeoPandas level

### Example

Low level example and benchmark. 4.6x reprojection speedup across 8 threads!

```py
import geodatasets
import pyarrow as pa
import geopandas as gpd
import numpy as np

from lonboard._geoarrow.geopandas_interop import geopandas_to_geoarrow
from lonboard._geoarrow.ops import reproject


path = geodatasets.get_path('nybb')
gdf = gpd.read_file(path)
table = geopandas_to_geoarrow(gdf)

field = table.schema.field(4)
column = table['geometry']
chunk = column.chunk(0)

new_chunked_array = pa.chunked_array([chunk] * 100)
%timeit out = reproject(field, new_chunked_array, max_workers=8)
# 693 ms ± 85.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
%timeit out = reproject(field, new_chunked_array, max_workers=1)
# 3.22 s ± 22 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```