### PR TITLE
Downgrade maplibre to <4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@deck.gl/react": "^8.9.34",
         "@geoarrow/deck.gl-layers": "^0.3.0-beta.11",
         "apache-arrow": "^15.0.0",
-        "maplibre-gl": "^4.0.0",
+        "maplibre-gl": "^3.6.2",
         "parquet-wasm": "0.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1684,14 +1684,6 @@
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.13.tgz",
       "integrity": "sha512-bmrNrgKMOhM3WsafmbGmC+6dsF2Z308vLFsQ3a/bT8X8Sv5clVYpPars/UPq+sAaJP+5OoLAYgwbkS5QEJdLUQ=="
     },
-    "node_modules/@types/geojson-vt": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
-      "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
-      "dependencies": {
-        "@types/geojson": "*"
-      }
-    },
     "node_modules/@types/hammerjs": {
       "version": "2.0.45",
       "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.45.tgz",
@@ -3009,9 +3001,9 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.0.0.tgz",
-      "integrity": "sha512-bzVQ2pdOWITwbE+JHKSiAB/viVBBx4Aa1puydc1xizOWGbvRHD9pXpy3dsaW2ZlbmZKbv9r9sHpcvM9fTLGsKA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-3.6.2.tgz",
+      "integrity": "sha512-krg2KFIdOpLPngONDhP6ixCoWl5kbdMINP0moMSJFVX7wX1Clm2M9hlNKXS8vBGlVWwR5R3ZfI6IPrYz7c+aCQ==",
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -3020,9 +3012,8 @@
         "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^20.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^19.3.3",
         "@types/geojson": "^7946.0.13",
-        "@types/geojson-vt": "3.2.5",
         "@types/mapbox__point-geometry": "^0.1.4",
         "@types/mapbox__vector-tile": "^1.3.4",
         "@types/pbf": "^3.0.5",
@@ -3047,29 +3038,6 @@
       "funding": {
         "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
       }
-    },
-    "node_modules/maplibre-gl/node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "20.1.1",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.1.1.tgz",
-      "integrity": "sha512-z85ARNPCBI2Cs5cPOS3DSbraTN+ue8zrcYVoSWBuNrD/mA+2SKAJ+hIzI22uN7gac6jBMnCdpPKRxS/V0KSZVQ==",
-      "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
-        "@mapbox/unitbezier": "^0.0.1",
-        "json-stringify-pretty-compact": "^4.0.0",
-        "minimist": "^1.2.8",
-        "rw": "^1.3.3",
-        "sort-object": "^3.0.3"
-      },
-      "bin": {
-        "gl-style-format": "dist/gl-style-format.mjs",
-        "gl-style-migrate": "dist/gl-style-migrate.mjs",
-        "gl-style-validate": "dist/gl-style-validate.mjs"
-      }
-    },
-    "node_modules/maplibre-gl/node_modules/json-stringify-pretty-compact": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
-      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q=="
     },
     "node_modules/math.gl": {
       "version": "3.6.3",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "comment": {
+    "maplibre": "Upgrading maplibre to v4 broke the basemap in static HTML exports."
+  },
   "dependencies": {
     "@anywidget/react": "^0.0.3",
     "@babel/runtime": "^7.23.9",
@@ -8,7 +11,7 @@
     "@deck.gl/react": "^8.9.34",
     "@geoarrow/deck.gl-layers": "^0.3.0-beta.11",
     "apache-arrow": "^15.0.0",
-    "maplibre-gl": "^4.0.0",
+    "maplibre-gl": "^3.6.2",
     "parquet-wasm": "0.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
Maplibre v4 breaks the basemap in the static HTML export