### PR TITLE
Fix: fix sliced array input for reprojection

### DIFF
--- a/tests/test_geoarrow.py
+++ b/tests/test_geoarrow.py
@@ -7,6 +7,7 @@ from pyproj import CRS
 from lonboard import SolidPolygonLayer
 from lonboard._constants import OGC_84
 from lonboard._geoarrow.geopandas_interop import geopandas_to_geoarrow
+from lonboard._geoarrow.ops.reproject import reproject_table
 from lonboard._utils import get_geometry_column_index
 
 
@@ -51,3 +52,12 @@ def test_geoarrow_table_reprojection():
     assert OGC_84 == CRS.from_json(
         reprojected_crs_str
     ), "layer should be reprojected to WGS84"
+
+
+def test_reproject_sliced_array():
+    """See https://github.com/developmentseed/lonboard/issues/390"""
+    gdf = gpd.read_file(geodatasets.get_path("nybb"))
+    table = geopandas_to_geoarrow(gdf)
+    sliced_table = table.slice(2)
+    # This should work even with a sliced array.
+    _reprojected = reproject_table(sliced_table, to_crs=OGC_84)


### PR DESCRIPTION
When operating on _sliced_ input, the physical offsets are incorrect because the current array points to a range not at the beginning of the array. So when creating new arrays that are not sliced, we need to subtract off the original offset of the first element.

This is the primary bug from https://github.com/developmentseed/lonboard/issues/390