### PR TITLE
Fix: Fix weighted centroid calculation

### DIFF
--- a/lonboard/_cli.py
+++ b/lonboard/_cli.py
@@ -11,9 +11,6 @@ from pyproj import CRS
 
 from lonboard import viz
 
-# path = Path("/Users/kyle/github/developmentseed/lonboard/DC_Wetlands.parquet")
-# path = Path("/Users/kyle/Downloads/UScounties.geojson")
-
 
 def read_pyogrio(path: Path) -> pa.Table:
     """Read path using pyogrio and convert field metadata to geoarrow

--- a/lonboard/_geoarrow/ops/centroid.py
+++ b/lonboard/_geoarrow/ops/centroid.py
@@ -73,7 +73,7 @@ class WeightedCentroid:
         new_chunk_modifier = new_chunk_len / (self.num_items + new_chunk_len)
 
         new_chunk_avg_x = np.mean(np_arr[:, 0])
-        new_chunk_avg_y = np.mean(np_arr[:, 0])
+        new_chunk_avg_y = np.mean(np_arr[:, 1])
 
         existing_x_avg = self.x
         existing_y_avg = self.y


### PR DESCRIPTION
The third bug found when looking into https://github.com/developmentseed/lonboard/issues/390. 

I can't believe I'd never hit this before, but I was using the x coordinate values to update the _y_ value of the weighted centroid. So you'd potentially get this error for any large datasets in the western hemisphere.