### PR TITLE
Parse GeoParquet metadata

### DIFF
--- a/lonboard/_geoarrow/parse_wkb.py
+++ b/lonboard/_geoarrow/parse_wkb.py
@@ -62,7 +62,7 @@ def parse_geoparquet_table(table: pa.Table) -> pa.Table:
     if column_meta["encoding"] == "WKB":
         existing_field = table.schema.field(column_idx)
         existing_column = table.column(column_idx)
-        crs_metadata = {"crs": OGC_84.to_json_dict()}
+        crs_metadata = {"crs": column_meta.get("crs", OGC_84.to_json_dict())}
         metadata = {
             b"ARROW:extension:name": EXTENSION_NAME.WKB,
             b"ARROW:extension:metadata": json.dumps(crs_metadata),

--- a/tests/test_geoarrow.py
+++ b/tests/test_geoarrow.py
@@ -1,7 +1,9 @@
 import json
+from tempfile import NamedTemporaryFile
 
 import geodatasets
 import geopandas as gpd
+import pyarrow.parquet as pq
 from pyproj import CRS
 
 from lonboard import SolidPolygonLayer
@@ -61,3 +63,13 @@ def test_reproject_sliced_array():
     sliced_table = table.slice(2)
     # This should work even with a sliced array.
     _reprojected = reproject_table(sliced_table, to_crs=OGC_84)
+
+
+def test_geoparquet_metadata():
+    gdf = gpd.read_file(geodatasets.get_path("nybb"))
+
+    with NamedTemporaryFile("+wb", suffix=".parquet") as f:
+        gdf.to_parquet(f)
+        table = pq.read_table(f)
+
+    _layer = SolidPolygonLayer(table=table)


### PR DESCRIPTION
Closes https://github.com/developmentseed/lonboard/issues/406

This should allow a two-liner for visualization of just

```py
table = pyarrow.parquet.read_table('file.parquet')
lonboard.viz(table)
```