### PR TITLE
Draft: Selection demo

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -165,7 +165,8 @@ function App() {
             // show selection area
             borderColor: "black",
             borderWidth: "1px",
-            backgroundColor: "rgba(0,0,1,0.5)",
+            borderStyle: "solid",
+            backgroundColor: "rgba(0,0,1,0.2)",
           }}
         />
       );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -119,6 +119,7 @@ function App() {
     }
   }, []);
 
+  // State is an array of: [screen coordinates, geographic coordinates]
   const [selectionStart, setSelectionStart] = useState<
     undefined | [[number, number], number[] | undefined]
   >();
@@ -142,6 +143,7 @@ function App() {
     // TODO: Recalculate this on layout change
     // TODO: Recalculate this on deckgl viewport change -- should be geo references
     if (selectionStart && selectionEnd) {
+      // Show the selected screen area
       const width = Math.abs(selectionEnd[0][0] - selectionStart[0][0]);
       const height = Math.abs(selectionEnd[0][1] - selectionStart[0][1]);
       const left = Math.min(selectionStart[0][0], selectionEnd[0][0]);
@@ -168,6 +170,7 @@ function App() {
         />
       );
     } else if (selectionStart) {
+      // Show the selection start point (note this does not show the proposed bounding box, but could be done)
       return (
         <div
           style={{
@@ -208,14 +211,7 @@ function App() {
         onClick={onClick}
       >
         <Map mapStyle={mapStyle || DEFAULT_MAP_STYLE} />
-        <div
-          style={{
-            height: "100%",
-            width: "100%",
-          }}
-        >
-          {selectionIndicator}
-        </div>
+        {selectionIndicator}
       </DeckGL>
     </div>
   );


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Adds a prototype of drawing a selection box on top of the DeckGL map. The selected coordinates are printed out.
- This is not a complete implementation because the box will not move when the map moves, which looks very strange. I also did not implement any of the selection-mode switching code.
- Draft per discussion with @kylebarron off Github.

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- See index.tsx. An HTML element is drawn on top of the map using relative screen coordinates. This element can be styled as with any element, so border, background, etc can all be customized. You can listen for some combination of layout events or Deck viewport events to redraw the element. You may need to add a DeckGL ref object in order to re-unproject the coordinates.

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
-Run the "North America Roads" example until the map is rendered

![Screenshot 2024-03-08 at 11 31 14 AM](https://github.com/developmentseed/lonboard/assets/9139378/b9113774-81c8-4af2-82dc-d1c5216fe188)

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- #148
