### PR TITLE
Use `MapboxOverlay` for handling Maplibre interaction?

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "@deck.gl/core": "^8.9.35",
         "@deck.gl/extensions": "^8.9.35",
         "@deck.gl/layers": "^8.9.35",
+        "@deck.gl/mapbox": "^8.9.35",
         "@deck.gl/react": "^8.9.35",
         "@geoarrow/deck.gl-layers": "^0.3.0-beta.15",
         "apache-arrow": "^15.0.1",
@@ -194,6 +195,18 @@
         "@deck.gl/core": "^8.0.0",
         "@loaders.gl/core": "^3.4.13",
         "@luma.gl/core": "^8.0.0"
+      }
+    },
+    "node_modules/@deck.gl/mapbox": {
+      "version": "8.9.35",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mapbox/-/mapbox-8.9.35.tgz",
+      "integrity": "sha512-3GKbYkB6OF+65Al/F2g0DlGhiQAPnA7/l/9Tl9cFSaaLBUfw2zT/U0kgZe3/4ZyfwQMzmoW6D3Ybb/FB4FKlmg==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@types/mapbox-gl": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "^8.0.0"
       }
     },
     "node_modules/@deck.gl/mesh-layers": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@deck.gl/core": "^8.9.35",
     "@deck.gl/extensions": "^8.9.35",
     "@deck.gl/layers": "^8.9.35",
+    "@deck.gl/mapbox": "^8.9.35",
     "@deck.gl/react": "^8.9.35",
     "@geoarrow/deck.gl-layers": "^0.3.0-beta.15",
     "apache-arrow": "^15.0.1",


### PR DESCRIPTION
### Change list

- Import Maplibre CSS with `import "maplibre-gl/dist/maplibre-gl.css";`. This is required to show the attribution control. Fixes https://github.com/developmentseed/lonboard/issues/436.
- Use `MapboxOverlay` for synchronizing Deck and Maplibre.

There's a wider question here: should Maplibre be a child of Deck or should Deck be a child of Maplibre? The Deck docs list [some limitations](https://deck.gl/docs/api-reference/mapbox/overview#limitations):

> * When using deck.gl's multi-view system, only one of the views can match the base map and receive interaction. See [using MapboxOverlay with multi-views](./mapbox-overlay.md#multi-view-usage) for details.
> * When using deck.gl as Mapbox layers or controls, `Deck` only receives a subset of user inputs delegated by `Map`. Therefore, certain interactive callbacks like `onDrag`, `onInteractionStateChange` are not available.
> * Mapbox/Maplibre's terrain features are partially supported. When a terrain is used, the camera of deck.gl and the base map should synchronize, however the deck.gl data with z=0 are rendered at the sea level and not aligned with the terrain surface.
> * Only Mercator projection is supported. Mapbox adaptive projection is not supported as their API doesn't expose the projection used.
> * The `position` property in `viewState` has no equivalent in mapbox-gl.

#### Maplibre as a child of Deck (not using MapboxOverlay)

- We should be able to have more low level control over visualization and be less tied to maplibre.
- For example, it would be really cool to visualize a side-by-side map, where you could swipe to see a before-and-after with two datasets. This option is required for this feature. Otherwise, when using `MapboxOverlay` [you can't have multiple interactive deck views](https://deck.gl/docs/api-reference/mapbox/mapbox-overlay#multi-view-usage).
- This also would keep us less tied to geospatial. So in theory non-geospatial users could use lonboard without a basemap, and still get to use all of lonboard's utilities for data serialization.

#### Deck as a child of Maplibre (using MapboxOverlay)

- Can use all Maplibre and Maplibre-compatible controls. In theory this should even include things like [mapbox-gl-draw](https://github.com/mapbox/mapbox-gl-draw). ([Upstream example](https://docs.mapbox.com/mapbox-gl-js/example/mapbox-gl-draw/)). In theory we wouldn't have to write our own, like we're doing in #417 
- Note that `fly_to` is now broken. This is because deck is no longer maintaining the view state itself.
