### PR TITLE
sync view state, move over code from #113, refs #112

### DIFF
--- a/lonboard/_map.py
+++ b/lonboard/_map.py
@@ -123,6 +123,11 @@ class Map(BaseAnyWidget):
     This API is not yet stabilized and may change in the future.
     """
 
+    _view_state = traitlets.Any(allow_none=True).tag(sync=True)
+    """
+    View state that is synced from the frontend
+    """
+
     _height = traitlets.Int(default_value=DEFAULT_HEIGHT, allow_none=True).tag(
         sync=True
     )
@@ -333,6 +338,6 @@ class Map(BaseAnyWidget):
             drop_defaults=False,
         )
 
-    @traitlets.default("_initial_view_state")
+    @traitlets.default("_view_state")
     def _default_initial_view_state(self):
         return compute_view(self.layers)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,7 +15,6 @@ import { Message } from "./types.js";
 import { flyTo } from "./actions/fly-to.js";
 import { useModelStateDebounced } from "./state";
 
-
 await initParquetWasm();
 
 const DEFAULT_INITIAL_VIEW_STATE = {
@@ -77,7 +76,7 @@ function App() {
   let [parameters] = useModelState<object>("parameters");
   const [viewState, setViewState] = useModelStateDebounced<MapViewState>(
     "_view_state",
-    300
+    300,
   );
   let [initialViewState, setInitialViewState] = useState(
     pythonInitialViewState,
@@ -170,11 +169,7 @@ function App() {
           overAlloc: 1,
           poolSize: 0,
         }}
-        viewState={
-          Object.keys(viewState).length === 0
-            ? DEFAULT_INITIAL_VIEW_STATE
-            : viewState
-        }
+        viewState={viewState}
         onViewStateChange={(event) => {
           // @ts-expect-error here viewState is typed as Record<string, any>
           setViewState(event.viewState);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,8 @@ import { isDefined, loadChildModels } from "./util.js";
 import { v4 as uuidv4 } from "uuid";
 import { Message } from "./types.js";
 import { flyTo } from "./actions/fly-to.js";
+import { useModelStateDebounced } from "./state";
+
 
 await initParquetWasm();
 
@@ -73,7 +75,10 @@ function App() {
   let [pickingRadius] = useModelState<number>("picking_radius");
   let [useDevicePixels] = useModelState<number | boolean>("use_device_pixels");
   let [parameters] = useModelState<object>("parameters");
-
+  const [viewState, setViewState] = useModelStateDebounced<MapViewState>(
+    "_view_state",
+    300
+  );
   let [initialViewState, setInitialViewState] = useState(
     pythonInitialViewState,
   );
@@ -147,13 +152,13 @@ function App() {
   return (
     <div id={`map-${mapId}`} style={{ height: mapHeight || "100%" }}>
       <DeckGL
-        initialViewState={
-          ["longitude", "latitude", "zoom"].every((key) =>
-            Object.keys(initialViewState).includes(key),
-          )
-            ? initialViewState
-            : DEFAULT_INITIAL_VIEW_STATE
-        }
+        // initialViewState={
+        //   ["longitude", "latitude", "zoom"].every((key) =>
+        //     Object.keys(initialViewState).includes(key),
+        //   )
+        //     ? initialViewState
+        //     : DEFAULT_INITIAL_VIEW_STATE
+        // }
         controller={true}
         layers={layers}
         // @ts-expect-error
@@ -164,6 +169,15 @@ function App() {
         _typedArrayManagerProps={{
           overAlloc: 1,
           poolSize: 0,
+        }}
+        viewState={
+          Object.keys(viewState).length === 0
+            ? DEFAULT_INITIAL_VIEW_STATE
+            : viewState
+        }
+        onViewStateChange={(event) => {
+          // @ts-expect-error here viewState is typed as Record<string, any>
+          setViewState(event.viewState);
         }}
         parameters={parameters || {}}
       >

--- a/src/state.ts
+++ b/src/state.ts
@@ -25,7 +25,7 @@ const debouncedModelSaveViewState = debounce((model) => {
 
 export function useModelStateDebounced<T>(
   key: string,
-  wait: number
+  wait: number,
 ): [T, (value: T) => void] {
   let model = useModel();
   let [value, setValue] = React.useState(model.get(key));

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,0 +1,51 @@
+import * as React from "react";
+import { useModel } from "@anywidget/react";
+import { debounce } from "./util";
+
+const debouncedModelSaveViewState = debounce((model) => {
+  console.log("DEBOUNCED");
+  const viewState = model.get("_view_state");
+
+  // transitionInterpolator is sometimes a key in the view state while panning
+  // This is a function object and so can't be serialized via JSON.
+  //
+  // In the future anywidget may support custom serializers for sending data
+  // back from JS to Python. Until then, we need to clean the object ourselves.
+  // Because this is in a debounce it shouldn't often mess with deck's internal
+  // transition state it expects, because hopefully the transition will have
+  // finished in the 300ms that the user has stopped panning.
+  if ("transitionInterpolator" in viewState) {
+    console.debug("Deleting transitionInterpolator!");
+    delete viewState.transitionInterpolator;
+    model.set("_view_state", viewState);
+  }
+
+  model.save_changes();
+}, 300);
+
+export function useModelStateDebounced<T>(
+  key: string,
+  wait: number
+): [T, (value: T) => void] {
+  let model = useModel();
+  let [value, setValue] = React.useState(model.get(key));
+  React.useEffect(() => {
+    let callback = () => {
+      console.log("callback");
+      console.log(model.get(key));
+      setValue(model.get(key));
+    };
+    model.on(`change:${key}`, callback);
+    console.log(`model on change view state`);
+    return () => model.off(`change:${key}`, callback);
+  }, [model, key]);
+  return [
+    value,
+    (value) => {
+      model.set(key, value);
+      // Note: I think this has to be defined outside of this function so that
+      // you're calling debounce on the same function object?
+      debouncedModelSaveViewState(model);
+    },
+  ];
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -21,3 +21,14 @@ export async function loadChildModels(
 export function isDefined<T>(value: T | undefined | null): value is T {
   return value !== undefined && value !== null;
 }
+
+// From https://www.joshwcomeau.com/snippets/javascript/debounce/
+export const debounce = (callback: (args) => void, wait: number) => {
+  let timeoutId = null;
+  return (...args) => {
+    window.clearTimeout(timeoutId);
+    timeoutId = window.setTimeout(() => {
+      callback.apply(null, args);
+    }, wait);
+  };
+};


### PR DESCRIPTION
Created a new PR toward #112, essentially copying over the code from #113, but applying it against `main`.

@kylebarron this seems to work!! It does seem to make the map a bit slow for me, and we should investigate that, but in principle, this for me works as expected.

On the javascript, I can move and zoom the map around and then in python call:

    m._view_state

Where `m` is a `Map` instance, and I get the current `viewState` as it is on the map.

Conversely, to modify the view state on the map, in Python I can do something like:

    new_state = m._view_state.copy()
    new_state['zoom'] = 8
    m._view_state = new_state

The above code works to set the `zoom` on the map to 8.

I think it will still be great to get eyes on this from React folks, and maybe think about if we could upstream the `useModelStateDebounced` method or so, but in principle, this seems to work!