### PR TITLE
Sync view state between JS and Python

### DIFF
--- a/docs/api/map.md
+++ b/docs/api/map.md
@@ -8,3 +8,6 @@ https://mkdocstrings.github.io/python/usage/configuration/members/#filters
       group_by_category: false
       show_bases: false
       filters:
+
+
+::: lonboard.models.ViewState

--- a/lonboard/_map.py
+++ b/lonboard/_map.py
@@ -278,7 +278,7 @@ class Map(BaseAnyWidget):
 
         Any parameters that are unset will not be changed.
 
-        Args:
+        Other Args:
             longitude: the new longitude to set on the map. Defaults to None.
             latitude: the new latitude to set on the map. Defaults to None.
             zoom: the new zoom to set on the map. Defaults to None.

--- a/lonboard/_map.py
+++ b/lonboard/_map.py
@@ -13,6 +13,7 @@ from lonboard._environment import DEFAULT_HEIGHT
 from lonboard._layer import BaseLayer
 from lonboard._viewport import compute_view
 from lonboard.basemap import CartoBasemap
+from lonboard.traits import DEFAULT_INITIAL_VIEW_STATE, ViewStateTrait
 from lonboard.types.map import MapKwargs
 
 if TYPE_CHECKING:
@@ -95,32 +96,28 @@ class Map(BaseAnyWidget):
     _esm = bundler_output_dir / "index.js"
     _css = bundler_output_dir / "index.css"
 
-    view_state = traitlets.Any(allow_none=True).tag(sync=True)
+    view_state = ViewStateTrait()
     """
     The view state of the map.
 
-    - Type: `dict`, optional
+    - Type: [`ViewState`][lonboard.models.ViewState]
     - Default: Automatically inferred from the data passed to the map.
 
-    The keys _must_ include:
+    You can initialize the map to a specific view state using this property:
 
-    - `longitude`: longitude at the map center.
-    - `latitude`: latitude at the map center.
-    - `zoom`: zoom level.
+    ```py
+    Map(
+        layers,
+        view_state={"longitude": -74.0060, "latitude": 40.7128, "zoom": 7}
+    )
+    ```
 
-    Keys may additionally include:
+    !!! note
 
-    - `pitch` (float, optional) - pitch angle in degrees. Default `0` (top-down).
-    - `bearing` (float, optional) - bearing angle in degrees. Default `0` (north).
-    - `maxZoom` (float, optional) - max zoom level. Default `20`.
-    - `minZoom` (float, optional) - min zoom level. Default `0`.
-    - `maxPitch` (float, optional) - max pitch angle. Default `60`.
-    - `minPitch` (float, optional) - min pitch angle. Default `0`.
+        The properties of the view state are immutable. Use
+        [`set_view_state`][lonboard.Map.set_view_state] to modify a map's view state
+        once it's been initially rendered.
 
-    Note that currently no camel-case/snake-case translation occurs for this method, and
-    so keys must be in camel case.
-
-    This API is not yet stabilized and may change in the future.
     """
 
     _height = traitlets.Int(default_value=DEFAULT_HEIGHT, allow_none=True).tag(
@@ -268,12 +265,51 @@ class Map(BaseAnyWidget):
       global `parameters` when that layer is rendered.
     """
 
+    def set_view_state(
+        self,
+        *,
+        longitude: Optional[float] = None,
+        latitude: Optional[float] = None,
+        zoom: Optional[float] = None,
+        pitch: Optional[float] = None,
+        bearing: Optional[float] = None,
+    ) -> None:
+        """Set the view state of the map.
+
+        Any parameters that are unset will not be changed.
+
+        Args:
+            longitude: the new longitude to set on the map. Defaults to None.
+            latitude: the new latitude to set on the map. Defaults to None.
+            zoom: the new zoom to set on the map. Defaults to None.
+            pitch: the new pitch to set on the map. Defaults to None.
+            bearing: the new bearing to set on the map. Defaults to None.
+        """
+        view_state = (
+            self.view_state._asdict()  # type: ignore
+            if self.view_state is not None
+            else DEFAULT_INITIAL_VIEW_STATE
+        )
+
+        if longitude is not None:
+            view_state["longitude"] = longitude
+        if latitude is not None:
+            view_state["latitude"] = latitude
+        if zoom is not None:
+            view_state["zoom"] = zoom
+        if pitch is not None:
+            view_state["pitch"] = pitch
+        if bearing is not None:
+            view_state["bearing"] = bearing
+
+        self.view_state = view_state
+
     def fly_to(
         self,
         *,
         longitude: Union[int, float],
         latitude: Union[int, float],
-        zoom: int,
+        zoom: float,
         duration: int = 4000,
         pitch: Union[int, float] = 0,
         bearing: Union[int, float] = 0,

--- a/lonboard/_map.py
+++ b/lonboard/_map.py
@@ -95,9 +95,9 @@ class Map(BaseAnyWidget):
     _esm = bundler_output_dir / "index.js"
     _css = bundler_output_dir / "index.css"
 
-    _initial_view_state = traitlets.Dict().tag(sync=True)
+    view_state = traitlets.Any(allow_none=True).tag(sync=True)
     """
-    The initial view state of the map.
+    The view state of the map.
 
     - Type: `dict`, optional
     - Default: Automatically inferred from the data passed to the map.
@@ -122,19 +122,6 @@ class Map(BaseAnyWidget):
 
     This API is not yet stabilized and may change in the future.
     """
-
-    _view_state = traitlets.Any(allow_none=True).tag(sync=True)
-    """
-    View state that is synced from the frontend
-    """
-
-    @property
-    def view_state(self):
-        return self._view_state
-
-    @view_state.setter
-    def view_state(self, view_state):
-        self.fly_to(**view_state, duration=0)
 
     _height = traitlets.Int(default_value=DEFAULT_HEIGHT, allow_none=True).tag(
         sync=True
@@ -346,6 +333,6 @@ class Map(BaseAnyWidget):
             drop_defaults=False,
         )
 
-    @traitlets.default("_view_state")
+    @traitlets.default("view_state")
     def _default_initial_view_state(self):
         return compute_view(self.layers)

--- a/lonboard/_map.py
+++ b/lonboard/_map.py
@@ -123,6 +123,11 @@ class Map(BaseAnyWidget):
     This API is not yet stabilized and may change in the future.
     """
 
+    _view_state = traitlets.Any(allow_none=True).tag(sync=True)
+    """
+    View state that is synced from the frontend
+    """
+
     _height = traitlets.Int(default_value=DEFAULT_HEIGHT, allow_none=True).tag(
         sync=True
     )
@@ -333,6 +338,6 @@ class Map(BaseAnyWidget):
             drop_defaults=False,
         )
 
-    @traitlets.default("_initial_view_state")
+    @traitlets.default("_view_state")
     def _default_initial_view_state(self):
         return compute_view(self.layers)

--- a/lonboard/_map.py
+++ b/lonboard/_map.py
@@ -128,6 +128,14 @@ class Map(BaseAnyWidget):
     View state that is synced from the frontend
     """
 
+    @property
+    def view_state(self):
+        return self._view_state
+
+    @view_state.setter
+    def view_state(self, view_state):
+        self.fly_to(**view_state, duration=0)
+
     _height = traitlets.Int(default_value=DEFAULT_HEIGHT, allow_none=True).tag(
         sync=True
     )

--- a/lonboard/_serialization.py
+++ b/lonboard/_serialization.py
@@ -1,12 +1,14 @@
 import math
 from io import BytesIO
-from typing import List, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import pyarrow as pa
 import pyarrow.parquet as pq
 from numpy.typing import NDArray
 from traitlets import TraitError
+
+from lonboard.models import ViewState
 
 DEFAULT_PARQUET_COMPRESSION = "ZSTD"
 DEFAULT_PARQUET_COMPRESSION_LEVEL = 7
@@ -86,6 +88,13 @@ def infer_rows_per_chunk(table: pa.Table) -> int:
 def validate_accessor_length_matches_table(accessor, table):
     if len(accessor) != len(table):
         raise TraitError("accessor must have same length as table")
+
+
+def serialize_view_state(data: Optional[ViewState], obj):
+    if data is None:
+        return None
+
+    return data._asdict()
 
 
 ACCESSOR_SERIALIZATION = {"to_json": serialize_accessor}

--- a/lonboard/_viewport.py
+++ b/lonboard/_viewport.py
@@ -62,6 +62,18 @@ def compute_view(layers: List[BaseLayer]):
     # When no geo column is found, bbox will have inf values
     try:
         zoom = bbox_to_zoom_level(bbox)
-        return {"longitude": center.x, "latitude": center.y, "zoom": zoom}
+        return {
+            "longitude": center.x,
+            "latitude": center.y,
+            "zoom": zoom,
+            "pitch": 0,
+            "bearing": 0,
+        }
     except OverflowError:
-        return {"longitude": center.x or 0, "latitude": center.y or 0, "zoom": 0}
+        return {
+            "longitude": center.x or 0,
+            "latitude": center.y or 0,
+            "zoom": 0,
+            "pitch": 0,
+            "bearing": 0,
+        }

--- a/lonboard/models.py
+++ b/lonboard/models.py
@@ -1,0 +1,18 @@
+from typing import NamedTuple
+
+
+class ViewState(NamedTuple):
+    longitude: float
+    """Longitude at the map center"""
+
+    latitude: float
+    """Latitude at the map center."""
+
+    zoom: float
+    """Zoom level."""
+
+    pitch: float
+    """Pitch angle in degrees. `0` is top-down."""
+
+    bearing: float
+    """Bearing angle in degrees. `0` is north."""

--- a/src/actions/fly-to.ts
+++ b/src/actions/fly-to.ts
@@ -1,11 +1,10 @@
-import { SetStateAction } from "react";
 import { FlyToMessage } from "../types";
 import { FlyToInterpolator, MapViewState } from "@deck.gl/core/typed";
 import { isDefined } from "../util";
 
 export function flyTo(
   msg: FlyToMessage,
-  setInitialViewState: (value: SetStateAction<MapViewState>) => void,
+  setInitialViewState: (value: MapViewState) => void,
 ) {
   const {
     longitude,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,7 +15,6 @@ import { Message } from "./types.js";
 import { flyTo } from "./actions/fly-to.js";
 import { useModelStateDebounced } from "./state";
 
-
 await initParquetWasm();
 
 const DEFAULT_INITIAL_VIEW_STATE = {
@@ -77,7 +76,7 @@ function App() {
   let [parameters] = useModelState<object>("parameters");
   const [viewState, setViewState] = useModelStateDebounced<MapViewState>(
     "_view_state",
-    300
+    300,
   );
   let [initialViewState, setInitialViewState] = useState(
     pythonInitialViewState,
@@ -170,11 +169,7 @@ function App() {
           overAlloc: 1,
           poolSize: 0,
         }}
-        viewState={
-          Object.keys(viewState).length === 0
-            ? DEFAULT_INITIAL_VIEW_STATE
-            : viewState
-        }
+        viewState={viewState}
         onViewStateChange={(event) => {
           // @ts-expect-error here viewState is typed as Record<string, any>
           setViewState(event.viewState);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -65,19 +65,15 @@ async function getChildModelState(
 function App() {
   let model = useModel();
 
-  let [pythonInitialViewState] = useModelState<MapViewState>(
-    "_initial_view_state",
-  );
   let [mapStyle] = useModelState<string>("basemap_style");
   let [mapHeight] = useModelState<number>("_height");
   let [showTooltip] = useModelState<boolean>("show_tooltip");
   let [pickingRadius] = useModelState<number>("picking_radius");
   let [useDevicePixels] = useModelState<number | boolean>("use_device_pixels");
   let [parameters] = useModelState<object>("parameters");
-  const [viewState, setViewState] = useModelStateDebounced<MapViewState>(
-    "_view_state",
-    300,
-  );
+  const [pythonInitialViewState, setViewState] =
+    useModelStateDebounced<MapViewState>("_view_state", 300);
+
   let [initialViewState, setInitialViewState] = useState(
     pythonInitialViewState,
   );
@@ -151,13 +147,13 @@ function App() {
   return (
     <div id={`map-${mapId}`} style={{ height: mapHeight || "100%" }}>
       <DeckGL
-        // initialViewState={
-        //   ["longitude", "latitude", "zoom"].every((key) =>
-        //     Object.keys(initialViewState).includes(key),
-        //   )
-        //     ? initialViewState
-        //     : DEFAULT_INITIAL_VIEW_STATE
-        // }
+        initialViewState={
+          ["longitude", "latitude", "zoom"].every((key) =>
+            Object.keys(initialViewState).includes(key),
+          )
+            ? initialViewState
+            : DEFAULT_INITIAL_VIEW_STATE
+        }
         controller={true}
         layers={layers}
         // @ts-expect-error
@@ -169,10 +165,16 @@ function App() {
           overAlloc: 1,
           poolSize: 0,
         }}
-        viewState={viewState}
         onViewStateChange={(event) => {
-          // @ts-expect-error here viewState is typed as Record<string, any>
-          setViewState(event.viewState);
+          const { viewState } = event;
+          const { longitude, latitude, zoom, pitch, bearing } = viewState;
+          setViewState({
+            longitude,
+            latitude,
+            zoom,
+            pitch,
+            bearing,
+          });
         }}
         parameters={parameters || {}}
       >

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,8 @@ import { isDefined, loadChildModels } from "./util.js";
 import { v4 as uuidv4 } from "uuid";
 import { Message } from "./types.js";
 import { flyTo } from "./actions/fly-to.js";
+import { useModelStateDebounced } from "./state";
+
 
 await initParquetWasm();
 
@@ -73,7 +75,10 @@ function App() {
   let [pickingRadius] = useModelState<number>("picking_radius");
   let [useDevicePixels] = useModelState<number | boolean>("use_device_pixels");
   let [parameters] = useModelState<object>("parameters");
-
+  const [viewState, setViewState] = useModelStateDebounced<MapViewState>(
+    "_view_state",
+    300
+  );
   let [initialViewState, setInitialViewState] = useState(
     pythonInitialViewState,
   );
@@ -147,13 +152,13 @@ function App() {
   return (
     <div id={`map-${mapId}`} style={{ height: mapHeight || "100%" }}>
       <DeckGL
-        initialViewState={
-          ["longitude", "latitude", "zoom"].every((key) =>
-            Object.keys(initialViewState).includes(key),
-          )
-            ? initialViewState
-            : DEFAULT_INITIAL_VIEW_STATE
-        }
+        // initialViewState={
+        //   ["longitude", "latitude", "zoom"].every((key) =>
+        //     Object.keys(initialViewState).includes(key),
+        //   )
+        //     ? initialViewState
+        //     : DEFAULT_INITIAL_VIEW_STATE
+        // }
         controller={true}
         layers={layers}
         // @ts-expect-error
@@ -164,6 +169,15 @@ function App() {
         _typedArrayManagerProps={{
           overAlloc: 1,
           poolSize: 0,
+        }}
+        viewState={
+          Object.keys(viewState).length === 0
+            ? DEFAULT_INITIAL_VIEW_STATE
+            : viewState
+        }
+        onViewStateChange={(event) => {
+          // @ts-expect-error here viewState is typed as Record<string, any>
+          setViewState(event.viewState);
         }}
         parameters={parameters || {}}
       >

--- a/src/model/layer.ts
+++ b/src/model/layer.ts
@@ -584,9 +584,6 @@ export class PolygonModel extends BaseArrowLayerModel {
   }
 
   layerProps(): Omit<GeoArrowPolygonLayerProps, "id"> {
-    console.log("table", this.table);
-    console.log("filled", this.filled);
-
     return {
       data: this.table,
       ...(isDefined(this.stroked) && { stroked: this.stroked }),

--- a/src/state.ts
+++ b/src/state.ts
@@ -3,7 +3,6 @@ import { useModel } from "@anywidget/react";
 import { debounce } from "./util";
 
 const debouncedModelSaveViewState = debounce((model) => {
-  console.log("DEBOUNCED");
   const viewState = model.get("_view_state");
 
   // transitionInterpolator is sometimes a key in the view state while panning
@@ -31,12 +30,9 @@ export function useModelStateDebounced<T>(
   let [value, setValue] = React.useState(model.get(key));
   React.useEffect(() => {
     let callback = () => {
-      console.log("callback");
-      console.log(model.get(key));
       setValue(model.get(key));
     };
     model.on(`change:${key}`, callback);
-    console.log(`model on change view state`);
     return () => model.off(`change:${key}`, callback);
   }, [model, key]);
   return [

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,8 +1,9 @@
 import * as React from "react";
 import { useModel } from "@anywidget/react";
+import type { AnyModel } from "@anywidget/types";
 import { debounce } from "./util";
 
-const debouncedModelSaveViewState = debounce((model) => {
+const debouncedModelSaveViewState = debounce((model: AnyModel) => {
   const viewState = model.get("_view_state");
 
   // transitionInterpolator is sometimes a key in the view state while panning

--- a/src/state.ts
+++ b/src/state.ts
@@ -25,7 +25,7 @@ const debouncedModelSaveViewState = debounce((model) => {
 
 export function useModelStateDebounced<T>(
   key: string,
-  wait: number
+  wait: number,
 ): [T, (value: T) => void] {
   let model = useModel();
   let [value, setValue] = React.useState(model.get(key));

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,0 +1,51 @@
+import * as React from "react";
+import { useModel } from "@anywidget/react";
+import { debounce } from "./util";
+
+const debouncedModelSaveViewState = debounce((model) => {
+  console.log("DEBOUNCED");
+  const viewState = model.get("_view_state");
+
+  // transitionInterpolator is sometimes a key in the view state while panning
+  // This is a function object and so can't be serialized via JSON.
+  //
+  // In the future anywidget may support custom serializers for sending data
+  // back from JS to Python. Until then, we need to clean the object ourselves.
+  // Because this is in a debounce it shouldn't often mess with deck's internal
+  // transition state it expects, because hopefully the transition will have
+  // finished in the 300ms that the user has stopped panning.
+  if ("transitionInterpolator" in viewState) {
+    console.debug("Deleting transitionInterpolator!");
+    delete viewState.transitionInterpolator;
+    model.set("_view_state", viewState);
+  }
+
+  model.save_changes();
+}, 300);
+
+export function useModelStateDebounced<T>(
+  key: string,
+  wait: number
+): [T, (value: T) => void] {
+  let model = useModel();
+  let [value, setValue] = React.useState(model.get(key));
+  React.useEffect(() => {
+    let callback = () => {
+      console.log("callback");
+      console.log(model.get(key));
+      setValue(model.get(key));
+    };
+    model.on(`change:${key}`, callback);
+    console.log(`model on change view state`);
+    return () => model.off(`change:${key}`, callback);
+  }, [model, key]);
+  return [
+    value,
+    (value) => {
+      model.set(key, value);
+      // Note: I think this has to be defined outside of this function so that
+      // you're calling debounce on the same function object?
+      debouncedModelSaveViewState(model);
+    },
+  ];
+}

--- a/src/state.ts
+++ b/src/state.ts
@@ -4,7 +4,8 @@ import type { AnyModel } from "@anywidget/types";
 import { debounce } from "./util";
 
 const debouncedModelSaveViewState = debounce((model: AnyModel) => {
-  const viewState = model.get("_view_state");
+  // TODO: this and below is hard-coded to the view_state model property!
+  const viewState = model.get("view_state");
 
   // transitionInterpolator is sometimes a key in the view state while panning
   // This is a function object and so can't be serialized via JSON.
@@ -17,16 +18,14 @@ const debouncedModelSaveViewState = debounce((model: AnyModel) => {
   if ("transitionInterpolator" in viewState) {
     console.debug("Deleting transitionInterpolator!");
     delete viewState.transitionInterpolator;
-    model.set("_view_state", viewState);
+    model.set("view_state", viewState);
   }
 
   model.save_changes();
 }, 300);
 
-export function useModelStateDebounced<T>(
-  key: string,
-  wait: number,
-): [T, (value: T) => void] {
+// TODO: add a `wait` parameter here, instead of having it hard-coded?
+export function useViewStateDebounced<T>(key: string): [T, (value: T) => void] {
   let model = useModel();
   let [value, setValue] = React.useState(model.get(key));
   React.useEffect(() => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -22,13 +22,12 @@ export function isDefined<T>(value: T | undefined | null): value is T {
   return value !== undefined && value !== null;
 }
 
-// From https://www.joshwcomeau.com/snippets/javascript/debounce/
-export const debounce = (callback: (args) => void, wait: number) => {
-  let timeoutId = null;
-  return (...args) => {
-    window.clearTimeout(timeoutId);
-    timeoutId = window.setTimeout(() => {
-      callback.apply(null, args);
-    }, wait);
+// From https://gist.github.com/ca0v/73a31f57b397606c9813472f7493a940
+export function debounce<T extends Function>(cb: T, wait = 20) {
+  let h: ReturnType<typeof setTimeout> | undefined;
+  let callable = (...args: any) => {
+    clearTimeout(h);
+    h = setTimeout(() => cb(...args), wait);
   };
-};
+  return <T>(<any>callable);
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -21,3 +21,14 @@ export async function loadChildModels(
 export function isDefined<T>(value: T | undefined | null): value is T {
   return value !== undefined && value !== null;
 }
+
+// From https://www.joshwcomeau.com/snippets/javascript/debounce/
+export const debounce = (callback: (args) => void, wait: number) => {
+  let timeoutId = null;
+  return (...args) => {
+    window.clearTimeout(timeoutId);
+    timeoutId = window.setTimeout(() => {
+      callback.apply(null, args);
+    }, wait);
+  };
+};


### PR DESCRIPTION
Closes https://github.com/developmentseed/lonboard/issues/112



In https://github.com/developmentseed/lonboard/pull/444 @batpad mentioned 

> It does seem to make the map a bit slow for me, and we should investigate that, but in principle, this for me works as expected

While playing around with that PR, I also saw some view state lagging at low zooms with lots of data rendered. In this screencast I'm smoothly zooming in, but the rendering is very jagged, and sometimes zooms back out slightly. **This screencast is of the previous PR**

https://github.com/developmentseed/lonboard/assets/15164633/bbe0a168-b76e-4563-bc30-828d648210db

My hypothesis of what's happening is that when rendering lots of data there's a slight lag for deck to call the `onViewStateChange` handler. And so deck will occasionally call the handler with "old" data and that's where you sometimes get the "snap back" in the scrolling.

I think this is a really bad UX, and it seems not to happen when deck manages the view state internally. So I think potentially the best UX and performance solution is to decouple the view state from the model, while still syncing from deck to Python in the debounced model handler.

This PR tries to implement this. 