### PR TITLE
Send WebAssembly binary over Jupyter WebSocket

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "vitest": "^1.4.0"
   },
   "scripts": {
-    "build": "node ./build.mjs",
+    "build": "node ./build.mjs && gzip -c node_modules/parquet-wasm/esm/arrow2_bg.wasm > lonboard/static/arrow2_bg.wasm.gz",
     "build:watch": "nodemon --watch src/ --exec \"npm run build\" --ext js,json,ts,tsx,css",
     "fmt:check": "prettier './src/**/*.{ts,tsx,css}' --check",
     "fmt": "prettier './src/**/*.{ts,tsx,css}' --write",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,13 @@ authors = ["Kyle Barron <kyle@developmentseed.org>"]
 license = "MIT"
 readme = "README.md"
 packages = [{ include = "lonboard" }]
-include = ["lonboard/static/*.js", "lonboard/static/*.css", "MANIFEST.in"]
+include = [
+    "lonboard/static/*.js",
+    "lonboard/static/*.css",
+    "lonboard/static/*.wasm",
+    "lonboard/static/*.wasm.gz",
+    "MANIFEST.in",
+]
 
 [tool.poetry.dependencies]
 python = "^3.8"

--- a/src/parquet.ts
+++ b/src/parquet.ts
@@ -1,20 +1,36 @@
 import { useEffect, useState } from "react";
-import _initParquetWasm, { readParquet } from "parquet-wasm/esm/arrow2";
+import { initSync, readParquet } from "parquet-wasm/esm/arrow2";
 import * as arrow from "apache-arrow";
 
-// NOTE: this version must be synced exactly with the parquet-wasm version in
-// use.
-const PARQUET_WASM_VERSION = "0.5.0";
-const PARQUET_WASM_CDN_URL = `https://cdn.jsdelivr.net/npm/parquet-wasm@${PARQUET_WASM_VERSION}/esm/arrow2_bg.wasm`;
 let WASM_READY: boolean = false;
 
-export async function initParquetWasm() {
-  if (WASM_READY) {
-    return;
+// https://developer.mozilla.org/en-US/docs/Web/API/Compression_Streams_API
+async function decompressBlob(blob: Blob) {
+  const ds = new DecompressionStream("gzip");
+  const decompressedStream = blob.stream().pipeThrough(ds);
+  return await new Response(decompressedStream).blob();
+}
+
+/**
+ * Initialize parquet-wasm from an existing WASM binary blob.
+ * It is expected that this WASM has been gzipped
+ *
+ * @return Whether initialization succeeded
+ */
+export async function initParquetWasmFromBinary(
+  view: DataView | null,
+): Promise<boolean> {
+  if (!view) {
+    return false;
   }
 
-  await _initParquetWasm(PARQUET_WASM_CDN_URL);
+  let blob = new Blob([view]);
+  const decompressedBlob = await decompressBlob(blob);
+  const decompressedBuffer = await decompressedBlob.arrayBuffer();
+
+  initSync(decompressedBuffer);
   WASM_READY = true;
+  return true;
 }
 
 /**
@@ -57,4 +73,22 @@ export function parseParquetBuffers(dataViews: DataView[]): arrow.Table {
   }
 
   return new arrow.Table(batches);
+}
+
+export function useParquetWasm(view: DataView | null): [boolean] {
+  const [wasmReady, setWasmReady] = useState<boolean>(false);
+
+  // Init parquet wasm
+  useEffect(() => {
+    const callback = async () => {
+      const succeeded = await initParquetWasmFromBinary(view);
+      if (succeeded) {
+        setWasmReady(true);
+      }
+    };
+
+    callback();
+  }, []);
+
+  return [wasmReady];
 }


### PR DESCRIPTION
[We use Parquet](https://developmentseed.org/lonboard/latest/how-it-works/internals/#parquet) as the internal format for data transfer. For reasons linked, Parquet is great. But to read Parquet on the client, we need to use a Wasm-based Parquet reader like my own https://github.com/kylebarron/parquet-wasm. Wasm-based libraries need a sidecar binary `.wasm` file, which is usually distributed separately.

We currently fetch this file from CDN, but for environments with a strong outbound firewall, a CDN may not be allowed. See https://github.com/developmentseed/lonboard/issues/457. To get around this, we serialize the gzipped Wasm content on the Anywidget model itself. We then decompress it on the client and pass it into Parquet-wasm's initializer.

Closes https://github.com/developmentseed/lonboard/issues/457