### PR TITLE
Fix parquet-wasm WASM version mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.9.1] - 2024-05-07
+
+### Fixes :bug:
+
+- Fix parquet-wasm WASM version mismatch by @kylebarron in https://github.com/developmentseed/lonboard/pull/508
+
+**Full Changelog**: https://github.com/developmentseed/lonboard/compare/v0.9.0...v0.9.1
+
 ## [0.9.0] - 2024-05-06
 
 ### New! :sparkles:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lonboard"
-version = "0.9.0"
+version = "0.9.1"
 description = "Python library for fast, interactive geospatial vector data visualization in Jupyter."
 authors = ["Kyle Barron <kyle@developmentseed.org>"]
 license = "MIT"

--- a/src/parquet.ts
+++ b/src/parquet.ts
@@ -3,7 +3,7 @@ import * as arrow from "apache-arrow";
 
 // NOTE: this version must be synced exactly with the parquet-wasm version in
 // use.
-const PARQUET_WASM_VERSION = "0.6.0";
+const PARQUET_WASM_VERSION = "0.6.1";
 const PARQUET_WASM_CDN_URL = `https://cdn.jsdelivr.net/npm/parquet-wasm@${PARQUET_WASM_VERSION}/esm/parquet_wasm_bg.wasm`;
 let WASM_READY: boolean = false;
 


### PR DESCRIPTION
### Change list

- Lonboard 0.9 is totally broken because the parquet-wasm JS version and the parquet-wasm WASM version didn't match 😭 