### PR TITLE
Feat: reverse the layer order for automatically split geometry

### DIFF
--- a/lonboard/_geoarrow/parse_wkb.py
+++ b/lonboard/_geoarrow/parse_wkb.py
@@ -54,8 +54,8 @@ def parse_wkb_table(table: pa.Table) -> List[pa.Table]:
     if GeometryType.LINEARRING in unique_type_ids:
         raise ValueError("LinearRings not currently supported")
 
-    point_indices = np.where(
-        (type_ids == GeometryType.POINT) | (type_ids == GeometryType.MULTIPOINT)
+    polygon_indices = np.where(
+        (type_ids == GeometryType.POLYGON) | (type_ids == GeometryType.MULTIPOLYGON)
     )[0]
 
     linestring_indices = np.where(
@@ -63,19 +63,19 @@ def parse_wkb_table(table: pa.Table) -> List[pa.Table]:
         | (type_ids == GeometryType.MULTILINESTRING)
     )[0]
 
-    polygon_indices = np.where(
-        (type_ids == GeometryType.POLYGON) | (type_ids == GeometryType.MULTIPOLYGON)
+    point_indices = np.where(
+        (type_ids == GeometryType.POINT) | (type_ids == GeometryType.MULTIPOINT)
     )[0]
 
-    if len(point_indices) > 0:
-        point_field, point_arr = construct_geometry_array(
-            shapely_arr[point_indices],
+    if len(polygon_indices) > 0:
+        polygon_field, polygon_arr = construct_geometry_array(
+            shapely_arr[polygon_indices],
             crs_str=crs_str,
         )
-        point_table = table.take(point_indices).set_column(
-            field_idx, point_field, point_arr
+        polygon_table = table.take(polygon_indices).set_column(
+            field_idx, polygon_field, polygon_arr
         )
-        parsed_tables.append(point_table)
+        parsed_tables.append(polygon_table)
 
     if len(linestring_indices) > 0:
         linestring_field, linestring_arr = construct_geometry_array(
@@ -87,15 +87,15 @@ def parse_wkb_table(table: pa.Table) -> List[pa.Table]:
         )
         parsed_tables.append(linestring_table)
 
-    if len(polygon_indices) > 0:
-        polygon_field, polygon_arr = construct_geometry_array(
-            shapely_arr[polygon_indices],
+    if len(point_indices) > 0:
+        point_field, point_arr = construct_geometry_array(
+            shapely_arr[point_indices],
             crs_str=crs_str,
         )
-        polygon_table = table.take(polygon_indices).set_column(
-            field_idx, polygon_field, polygon_arr
+        point_table = table.take(point_indices).set_column(
+            field_idx, point_field, point_arr
         )
-        parsed_tables.append(polygon_table)
+        parsed_tables.append(point_table)
 
     return parsed_tables
 

--- a/lonboard/_geoarrow/parse_wkb.py
+++ b/lonboard/_geoarrow/parse_wkb.py
@@ -83,10 +83,12 @@ def parse_wkb_table(table: pa.Table) -> List[pa.Table]:
                     crs_str=crs_str,
                 )
             )
-            geometry_table = table.take(single_type_geometry_indices).set_column(
+            single_type_geometry_table = table.take(
+                single_type_geometry_indices
+            ).set_column(
                 field_idx, single_type_geometry_field, single_type_geometry_arr
             )
-            parsed_tables.append(geometry_table)
+            parsed_tables.append(single_type_geometry_table)
 
     return parsed_tables
 

--- a/lonboard/_geoarrow/parse_wkb.py
+++ b/lonboard/_geoarrow/parse_wkb.py
@@ -54,8 +54,8 @@ def parse_wkb_table(table: pa.Table) -> List[pa.Table]:
     if GeometryType.LINEARRING in unique_type_ids:
         raise ValueError("LinearRings not currently supported")
 
-    polygon_indices = np.where(
-        (type_ids == GeometryType.POLYGON) | (type_ids == GeometryType.MULTIPOLYGON)
+    point_indices = np.where(
+        (type_ids == GeometryType.POINT) | (type_ids == GeometryType.MULTIPOINT)
     )[0]
 
     linestring_indices = np.where(
@@ -63,39 +63,30 @@ def parse_wkb_table(table: pa.Table) -> List[pa.Table]:
         | (type_ids == GeometryType.MULTILINESTRING)
     )[0]
 
-    point_indices = np.where(
-        (type_ids == GeometryType.POINT) | (type_ids == GeometryType.MULTIPOINT)
+    polygon_indices = np.where(
+        (type_ids == GeometryType.POLYGON) | (type_ids == GeometryType.MULTIPOLYGON)
     )[0]
 
-    if len(polygon_indices) > 0:
-        polygon_field, polygon_arr = construct_geometry_array(
-            shapely_arr[polygon_indices],
-            crs_str=crs_str,
-        )
-        polygon_table = table.take(polygon_indices).set_column(
-            field_idx, polygon_field, polygon_arr
-        )
-        parsed_tables.append(polygon_table)
-
-    if len(linestring_indices) > 0:
-        linestring_field, linestring_arr = construct_geometry_array(
-            shapely_arr[linestring_indices],
-            crs_str=crs_str,
-        )
-        linestring_table = table.take(linestring_indices).set_column(
-            field_idx, linestring_field, linestring_arr
-        )
-        parsed_tables.append(linestring_table)
-
-    if len(point_indices) > 0:
-        point_field, point_arr = construct_geometry_array(
-            shapely_arr[point_indices],
-            crs_str=crs_str,
-        )
-        point_table = table.take(point_indices).set_column(
-            field_idx, point_field, point_arr
-        )
-        parsed_tables.append(point_table)
+    # Here we intentionally check geometries in a specific order.
+    # Starting from polygons, then linestrings, then points,
+    # so that the order of generated layers is polygon, then path then scatterplot.
+    # This ensures that points are rendered on top and polygons on the bottom.
+    for single_type_geometry_indices in (
+        polygon_indices,
+        linestring_indices,
+        point_indices,
+    ):
+        if len(single_type_geometry_indices) > 0:
+            single_type_geometry_field, single_type_geometry_arr = (
+                construct_geometry_array(
+                    shapely_arr[single_type_geometry_indices],
+                    crs_str=crs_str,
+                )
+            )
+            geometry_table = table.take(single_type_geometry_indices).set_column(
+                field_idx, single_type_geometry_field, single_type_geometry_arr
+            )
+            parsed_tables.append(geometry_table)
 
     return parsed_tables
 

--- a/lonboard/_geoarrow/parse_wkb.py
+++ b/lonboard/_geoarrow/parse_wkb.py
@@ -41,7 +41,6 @@ def parse_wkb_table(table: pa.Table) -> List[pa.Table]:
         return [table]
 
     # Handle WKB input
-    parsed_tables = []
     crs_str = get_field_crs(field)
     shapely_arr = shapely.from_wkb(column)
 
@@ -71,6 +70,7 @@ def parse_wkb_table(table: pa.Table) -> List[pa.Table]:
     # Starting from polygons, then linestrings, then points,
     # so that the order of generated layers is polygon, then path then scatterplot.
     # This ensures that points are rendered on top and polygons on the bottom.
+    parsed_tables = []
     for single_type_geometry_indices in (
         polygon_indices,
         linestring_indices,

--- a/lonboard/_utils.py
+++ b/lonboard/_utils.py
@@ -140,8 +140,6 @@ def split_mixed_gdf(gdf: gpd.GeoDataFrame) -> List[gpd.GeoDataFrame]:
         if unique_type_ids == {GeometryType.POLYGON, GeometryType.MULTIPOLYGON}:
             return [gdf]
 
-    gdfs = []
-
     point_indices = np.where(
         (type_ids == GeometryType.POINT) | (type_ids == GeometryType.MULTIPOINT)
     )[0]
@@ -159,6 +157,7 @@ def split_mixed_gdf(gdf: gpd.GeoDataFrame) -> List[gpd.GeoDataFrame]:
     # Starting from polygons, then linestrings, then points,
     # so that the order of generated layers is polygon, then path then scatterplot.
     # This ensures that points are rendered on top and polygons on the bottom.
+    gdfs = []
     for single_type_geometry_indices in (
         polygon_indices,
         linestring_indices,

--- a/lonboard/_utils.py
+++ b/lonboard/_utils.py
@@ -159,12 +159,12 @@ def split_mixed_gdf(gdf: gpd.GeoDataFrame) -> List[gpd.GeoDataFrame]:
     # Starting from polygons, then linestrings, then points,
     # so that the order of generated layers is polygon, then path then scatterplot.
     # This ensures that points are rendered on top and polygons on the bottom.
-    for single_typ_geometry_indices in (
+    for single_type_geometry_indices in (
         polygon_indices,
         linestring_indices,
         point_indices,
     ):
-        if len(single_typ_geometry_indices) > 0:
-            gdfs.append(gdf.iloc[single_typ_geometry_indices])
+        if len(single_type_geometry_indices) > 0:
+            gdfs.append(gdf.iloc[single_type_geometry_indices])
 
     return gdfs

--- a/lonboard/_utils.py
+++ b/lonboard/_utils.py
@@ -131,21 +131,21 @@ def split_mixed_gdf(gdf: gpd.GeoDataFrame) -> List[gpd.GeoDataFrame]:
         return [gdf]
 
     if len(unique_type_ids) == 2:
-        if unique_type_ids == {GeometryType.POINT, GeometryType.MULTIPOINT}:
+        if unique_type_ids == {GeometryType.POLYGON, GeometryType.MULTIPOLYGON}:
             return [gdf]
 
         if unique_type_ids == {GeometryType.LINESTRING, GeometryType.MULTILINESTRING}:
             return [gdf]
 
-        if unique_type_ids == {GeometryType.POLYGON, GeometryType.MULTIPOLYGON}:
+        if unique_type_ids == {GeometryType.POINT, GeometryType.MULTIPOINT}:
             return [gdf]
 
     gdfs = []
-    point_indices = np.where(
-        (type_ids == GeometryType.POINT) | (type_ids == GeometryType.MULTIPOINT)
+    polygon_indices = np.where(
+        (type_ids == GeometryType.POLYGON) | (type_ids == GeometryType.MULTIPOLYGON)
     )[0]
-    if len(point_indices) > 0:
-        gdfs.append(gdf.iloc[point_indices])
+    if len(polygon_indices) > 0:
+        gdfs.append(gdf.iloc[polygon_indices])
 
     linestring_indices = np.where(
         (type_ids == GeometryType.LINESTRING)
@@ -154,10 +154,10 @@ def split_mixed_gdf(gdf: gpd.GeoDataFrame) -> List[gpd.GeoDataFrame]:
     if len(linestring_indices) > 0:
         gdfs.append(gdf.iloc[linestring_indices])
 
-    polygon_indices = np.where(
-        (type_ids == GeometryType.POLYGON) | (type_ids == GeometryType.MULTIPOLYGON)
+    point_indices = np.where(
+        (type_ids == GeometryType.POINT) | (type_ids == GeometryType.MULTIPOINT)
     )[0]
-    if len(polygon_indices) > 0:
-        gdfs.append(gdf.iloc[polygon_indices])
+    if len(point_indices) > 0:
+        gdfs.append(gdf.iloc[point_indices])
 
     return gdfs

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -47,9 +47,9 @@ def test_viz_wkb_pyarrow():
 def test_viz_wkb_mixed_pyarrow():
     table = pq.read_table(fixtures_dir / "monaco_nofilter_noclip_compact.parquet")
     map_ = viz(table)
-    assert isinstance(map_.layers[0], ScatterplotLayer)
+    assert isinstance(map_.layers[0], PolygonLayer)
     assert isinstance(map_.layers[1], PathLayer)
-    assert isinstance(map_.layers[2], PolygonLayer)
+    assert isinstance(map_.layers[2], ScatterplotLayer)
 
 
 def test_viz_reproject():
@@ -84,9 +84,9 @@ def test_viz_geo_interface_mixed_feature_collection():
     geo_interface_obj = GeoInterfaceHolder(gdf)
     map_ = viz(geo_interface_obj)
 
-    assert isinstance(map_.layers[0], ScatterplotLayer)
+    assert isinstance(map_.layers[0], PolygonLayer)
     assert isinstance(map_.layers[1], PathLayer)
-    assert isinstance(map_.layers[2], PolygonLayer)
+    assert isinstance(map_.layers[2], ScatterplotLayer)
 
 
 def test_viz_geopandas_geodataframe():
@@ -105,9 +105,9 @@ def test_viz_shapely_mixed_array():
     geoms = mixed_shapely_geoms()
     map_ = viz(geoms)
 
-    assert isinstance(map_.layers[0], ScatterplotLayer)
+    assert isinstance(map_.layers[0], PolygonLayer)
     assert isinstance(map_.layers[1], PathLayer)
-    assert isinstance(map_.layers[2], PolygonLayer)
+    assert isinstance(map_.layers[2], ScatterplotLayer)
 
 
 def test_viz_geoarrow_rust_table():

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -105,9 +105,9 @@ def test_viz_shapely_mixed_array():
     geoms = mixed_shapely_geoms()
     map_ = viz(geoms)
 
-    assert isinstance(map_.layers[0], PolygonLayer)
+    assert isinstance(map_.layers[0], ScatterplotLayer)
     assert isinstance(map_.layers[1], PathLayer)
-    assert isinstance(map_.layers[2], ScatterplotLayer)
+    assert isinstance(map_.layers[2], PolygonLayer)
 
 
 def test_viz_geoarrow_rust_table():


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Layer order for objects with mixed geometry types

## How I did it
Changed list appending order for `split_mixed_gdf` and `parse_wkb_table` function from [`points`, `linestrings`, `polygons`] to [`polygons`, `linestrings`, `points`]

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Points and paths should be now plotted on top of polygon for better visibility.

Old:
![Untitled](https://github.com/developmentseed/lonboard/assets/17250607/f0d4a4f5-d69d-4e27-bbc7-3d159d1d2e6b)

New:
![image](https://github.com/developmentseed/lonboard/assets/17250607/8e154ff7-996a-4556-9406-daa355d4184a)

## Related Issues
#513 
