### PR TITLE
Simplify migration example

### DIFF
--- a/examples/migration.ipynb
+++ b/examples/migration.ipynb
@@ -7,11 +7,11 @@
    "source": [
     "# U.S. County-to-County Migration\n",
     "\n",
-    "This notebook is derived from the original deck.gl example in JavaScript, which you can see [here](https://deck.gl/examples/brushing-extension). \n",
+    "This notebook is derived from the original deck.gl example in JavaScript, which you can see [here](https://deck.gl/examples/brushing-extension).\n",
     "\n",
     "This dataset originally came from the U.S. Census Bureau and represents people moving in and out of each county between 2009-2013.\n",
     "\n",
-    "You can view a [hosted version of this notebook on Notebook Sharing Space](https://notebooksharing.space/view/1ce5db3fbfc7806587325d68a82f8553d152c05b4f3bd07d3cc84a85f1e3d619#displayOptions=) (6MB download)."
+    "You can view a [hosted version of this notebook on Notebook Sharing Space](https://notebooksharing.space/view/1ce5db3fbfc7806587325d68a82f8553d152c05b4f3bd07d3cc84a85f1e3d619#displayOptions=) (6MB download).\n"
    ]
   },
   {
@@ -19,7 +19,7 @@
    "id": "b73b22ff",
    "metadata": {},
    "source": [
-    "## Imports"
+    "## Imports\n"
    ]
   },
   {
@@ -47,7 +47,7 @@
    "id": "35467684",
    "metadata": {},
    "source": [
-    "Fetch the data from the version in the `deck.gl-data` repository."
+    "Fetch the data from the version in the `deck.gl-data` repository.\n"
    ]
   },
   {
@@ -67,9 +67,9 @@
    "id": "5a68a643",
    "metadata": {},
    "source": [
-    "The following cell may be a little hard to follow, but what it's doing is taking the raw data, which represents a [_graph_](https://en.wikipedia.org/wiki/Graph_(abstract_data_type)) of the data and normalizing it to a table structure where each row represents one \"arc\" between a source and target county.\n",
+    "The following cell may be a little hard to follow, but what it's doing is taking the raw data, which represents a [_graph_](<https://en.wikipedia.org/wiki/Graph_(abstract_data_type)>) of the data and normalizing it to a table structure where each row represents one \"arc\" between a source and target county.\n",
     "\n",
-    "This is ported from the original JavaScript [here](https://github.com/visgl/deck.gl/blob/b16f51509d4483c91fb3e418d063a7ca5b0e5387/examples/website/brushing/app.jsx#L37-L103)."
+    "This is ported from the original JavaScript [here](https://github.com/visgl/deck.gl/blob/b16f51509d4483c91fb3e418d063a7ca5b0e5387/examples/website/brushing/app.jsx#L37-L103).\n"
    ]
   },
   {
@@ -166,8 +166,8 @@
     "\n",
     "```json\n",
     "[\n",
-    "    [166,   3,   3],\n",
-    "    [ 35, 181, 184]\n",
+    "  [166, 3, 3],\n",
+    "  [35, 181, 184]\n",
     "]\n",
     "```\n",
     "\n",
@@ -177,14 +177,14 @@
     "\n",
     "```json\n",
     "[\n",
-    "    [166,   3,   3],\n",
-    "    [ 35, 181, 184],\n",
-    "    [166,   3,   3],\n",
-    "    [166,   3,   3]\n",
+    "  [166, 3, 3],\n",
+    "  [35, 181, 184],\n",
+    "  [166, 3, 3],\n",
+    "  [166, 3, 3]\n",
     "]\n",
     "```\n",
     "\n",
-    "equal to the number of rows in our dataset. We can then pass this to any parameter that accepts a [ColorAccessor](https://developmentseed.org/lonboard/latest/api/traits/#lonboard.traits.ColorAccessor)."
+    "equal to the number of rows in our dataset. We can then pass this to any parameter that accepts a [ColorAccessor](https://developmentseed.org/lonboard/latest/api/traits/#lonboard.traits.ColorAccessor).\n"
    ]
   },
   {
@@ -222,7 +222,7 @@
    "id": "be8475b7",
    "metadata": {},
    "source": [
-    "Convert the `sources` list of dictionaries into a GeoPandas `GeoDataFrame` to pass into a `ScatterplotLayer`."
+    "Convert the `sources` list of dictionaries into a GeoPandas `GeoDataFrame` to pass into a `ScatterplotLayer`.\n"
    ]
   },
   {
@@ -237,7 +237,7 @@
     "source_gdf = gpd.GeoDataFrame(\n",
     "    pd.DataFrame.from_records(sources)[[\"name\", \"radius\", \"gain\"]],\n",
     "    geometry=source_positions,\n",
-    "    crs=\"EPSG:4326\"\n",
+    "    crs=\"EPSG:4326\",\n",
     ")\n",
     "# We use a lookup table (`COLORS`) to apply either the target color or the source color\n",
     "# to the array\n",
@@ -250,7 +250,7 @@
    "id": "506ba6a7",
    "metadata": {},
    "source": [
-    "Create a `ScatterplotLayer` for source points:"
+    "Create a `ScatterplotLayer` for source points:\n"
    ]
   },
   {
@@ -282,11 +282,13 @@
     "target_gdf = gpd.GeoDataFrame(\n",
     "    pd.DataFrame.from_records(targets)[[\"name\", \"gain\", \"loss\", \"net\"]],\n",
     "    geometry=target_positions,\n",
-    "    crs=\"EPSG:4326\"\n",
+    "    crs=\"EPSG:4326\",\n",
     ")\n",
     "# We use a lookup table (`COLORS`) to apply either the target color or the source color\n",
     "# to the array\n",
-    "target_line_colors_lookup = np.where(target_gdf[\"net\"] > 0, TARGET_LOOKUP, SOURCE_LOOKUP)\n",
+    "target_line_colors_lookup = np.where(\n",
+    "    target_gdf[\"net\"] > 0, TARGET_LOOKUP, SOURCE_LOOKUP\n",
+    ")\n",
     "target_line_colors = COLORS[target_line_colors_lookup]"
    ]
   },
@@ -295,7 +297,7 @@
    "id": "bf29c60d",
    "metadata": {},
    "source": [
-    "Create a `ScatterplotLayer` for target points:"
+    "Create a `ScatterplotLayer` for target points:\n"
    ]
   },
   {
@@ -327,7 +329,7 @@
     "needs _two_ point columns, not one. This is a large part of why it's still\n",
     "marked under the \"experimental\" module.\n",
     "\n",
-    "Here we pass a numpy array for each point column. This is allowed as long as the shape of the array is `(N, 2)` or `(N, 3)` (i.e. 2D or 3D coordinates)."
+    "Here we pass a numpy array for each point column. This is allowed as long as the shape of the array is `(N, 2)` or `(N, 3)` (i.e. 2D or 3D coordinates).\n"
    ]
   },
   {
@@ -365,7 +367,7 @@
     "\n",
     "As you hover over the map, it should render only the arcs near your cursor.\n",
     "\n",
-    "You can modify `brushing_extension.brushing_radius` to control how large the brush is around your cursor."
+    "You can modify `brushing_extension.brushing_radius` to control how large the brush is around your cursor.\n"
    ]
   },
   {
@@ -391,7 +393,7 @@
     }
    ],
    "source": [
-    "map_ = Map(layers=[source_layer, target_ring_layer, arc_layer], picking_radius=10)\n",
+    "map_ = Map([source_layer, target_ring_layer, arc_layer], picking_radius=10)\n",
     "map_"
    ]
   },


### PR DESCRIPTION
- Remove `layers=` keyword arg passing
- Reformat notebook with ruff