### PR TITLE
Fix attribution

### DIFF
--- a/lonboard/_map.py
+++ b/lonboard/_map.py
@@ -176,12 +176,15 @@ class Map(BaseAnyWidget):
     """
     Custom attribution to display on the map.
 
-    This attribute supports the same format as the `attribution` property in the Maplibre API.
+    This attribute supports the same format as the `attribution` property in the
+    Maplibre API.
 
     - Type: `str` or `List[str]`
     - Default: `None`
 
-    You can provide either a single string or a list of strings for custom attributions. If an attribution value is set in the map style, it will be displayed in addition to this custom attribution.
+    You can provide either a single string or a list of strings for custom attributions.
+    If an attribution value is set in the map style, it will be displayed in addition to
+    this custom attribution.
 
     **Example:**
 

--- a/lonboard/_map.py
+++ b/lonboard/_map.py
@@ -167,6 +167,38 @@ class Map(BaseAnyWidget):
       [`lonboard.basemap.CartoBasemap.PositronNoLabels`][lonboard.basemap.CartoBasemap.PositronNoLabels]
     """
 
+    custom_attribution = traitlets.Union(
+        [traitlets.Unicode(allow_none=True), traitlets.List(traitlets.Unicode(allow_none=False))]
+    ).tag(sync=True)
+    """
+    Custom attribution to display on the map.
+
+    This attribute supports the same format as the `attribution` property in the Maplibre API.
+
+    - Type: `str` or `List[str]`
+    - Default: `None`
+
+    You can provide either a single string or a list of strings for custom attributions. If an attribution value is set in the map style, it will be displayed in addition to this custom attribution.
+
+    **Example:**
+    
+        ```py
+        m = Map(
+            layers,
+            custom_attribution="Development Seed"
+        )
+        ```
+
+    **Example:**
+
+        ```py
+        m = Map(
+            layers,
+            custom_attribution=["Development Seed", "OpenStreetMap"]
+        )
+        ```
+    """
+
     # TODO: We'd prefer a "Strict union of bool and float" but that doesn't
     # work here because `Union[bool, float]` would coerce `1` to `True`, which we don't
     # want, and `Union[float, bool]` would coerce `True` to `1`, which we also don't

--- a/lonboard/_map.py
+++ b/lonboard/_map.py
@@ -168,7 +168,10 @@ class Map(BaseAnyWidget):
     """
 
     custom_attribution = traitlets.Union(
-        [traitlets.Unicode(allow_none=True), traitlets.List(traitlets.Unicode(allow_none=False))]
+        [
+            traitlets.Unicode(allow_none=True),
+            traitlets.List(traitlets.Unicode(allow_none=False)),
+        ]
     ).tag(sync=True)
     """
     Custom attribution to display on the map.
@@ -181,7 +184,7 @@ class Map(BaseAnyWidget):
     You can provide either a single string or a list of strings for custom attributions. If an attribution value is set in the map style, it will be displayed in addition to this custom attribution.
 
     **Example:**
-    
+
         ```py
         m = Map(
             layers,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -72,6 +72,7 @@ function App() {
   let [pickingRadius] = useModelState<number>("picking_radius");
   let [useDevicePixels] = useModelState<number | boolean>("use_device_pixels");
   let [parameters] = useModelState<object>("parameters");
+  let [customAttribution] = useModelState<string>("custom_attribution");
 
   // initialViewState is the value of view_state on the Python side. This is
   // called `initial` here because it gets passed in to deck's
@@ -185,7 +186,10 @@ function App() {
         }}
         parameters={parameters || {}}
       >
-        <Map mapStyle={mapStyle || DEFAULT_MAP_STYLE} />
+        <Map
+          mapStyle={mapStyle || DEFAULT_MAP_STYLE}
+          customAttribution={customAttribution}
+        ></Map>
       </DeckGL>
     </div>
   );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,7 @@ import { v4 as uuidv4 } from "uuid";
 import { Message } from "./types.js";
 import { flyTo } from "./actions/fly-to.js";
 import { useViewStateDebounced } from "./state";
+import "maplibre-gl/dist/maplibre-gl.css";
 
 await initParquetWasm();
 

--- a/src/model/base-layer.ts
+++ b/src/model/base-layer.ts
@@ -62,8 +62,6 @@ export abstract class BaseLayerModel extends BaseModel {
   }
 
   baseLayerProps(): LayerProps {
-    // console.log("extensions", this.extensionInstances());
-    // console.log("extensionprops", this.extensionProps());
     return {
       extensions: this.extensionInstances(),
       ...this.extensionProps(),


### PR DESCRIPTION
This adds a `custom_attribution` property to the `Map` class and fix Maplibre CSS by adding an import. Contributes to:

- #436
- #545

To test, add the `custom_attribution` property to a Map instance as demonstrated in the API docs examples.

@kylebarron this is ready for review.