### PR TITLE
Fix bbox map select feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "lonboard",
+  "name": "lonboard-batpad",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -14,6 +14,7 @@
         "@geoarrow/deck.gl-layers": "^0.3.0-beta.16",
         "apache-arrow": "^15.0.2",
         "maplibre-gl": "^3.6.2",
+        "memoize-one": "^6.0.0",
         "parquet-wasm": "0.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -3040,6 +3041,11 @@
       "dependencies": {
         "@math.gl/core": "3.6.3"
       }
+    },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@geoarrow/deck.gl-layers": "^0.3.0-beta.16",
     "apache-arrow": "^15.0.2",
     "maplibre-gl": "^3.6.2",
+    "memoize-one": "^6.0.0",
     "parquet-wasm": "0.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,12 @@
-import React, { useCallback, useReducer, useRef } from "react";
-import { useState, useEffect } from "react";
+import * as React from "react";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { createRender, useModelState, useModel } from "@anywidget/react";
 import type { Initialize, Render } from "@anywidget/types";
 import Map from "react-map-gl/maplibre";
 import DeckGL, { DeckGLRef } from "@deck.gl/react/typed";
-import { MapViewState, PickingInfo, type Layer } from "@deck.gl/core/typed";
+import { PolygonLayer } from "@deck.gl/layers/typed";
+import type { PickingInfo } from "@deck.gl/core/typed";
+import { MapViewState, type Layer } from "@deck.gl/core/typed";
 import { BaseLayerModel, initializeLayer } from "./model/index.js";
 import type { WidgetModel } from "@jupyter-widgets/base";
 import { initParquetWasm } from "./parquet.js";
@@ -15,9 +17,6 @@ import { Message } from "./types.js";
 import { flyTo } from "./actions/fly-to.js";
 import { useViewStateDebounced } from "./state";
 import * as selectors from "./reducer/selectors";
-
-import "maplibre-gl/dist/maplibre-gl.css";
-
 import {
   ActionTypes,
   baseInitialState,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -196,6 +196,13 @@ function App() {
     [isMapHoverEnabled, justClicked],
   );
 
+  let buttonLabel = "Click here to start selecting";
+  if (state.mapMode === MapMode.BBOX_SELECT_START) {
+    buttonLabel = "Click the map to start drawing the selection box";
+  } else if (state.mapMode === MapMode.BBOX_SELECT_UPDATE) {
+    buttonLabel = "Click the map to finish drawing the selection box";
+  }
+
   return (
     <div id={`map-${mapId}`} style={{ height: mapHeight || "100%" }}>
       <div
@@ -212,9 +219,7 @@ function App() {
           dispatch({ type: ActionTypes.TOGGLE_BBOX_SELECT_MODE });
         }}
       >
-        {state.mapMode === MapMode.BBOX_SELECT_START
-          ? "Bbox select mode"
-          : "Pan mode"}
+        {buttonLabel}
       </div>
       <DeckGL
         initialViewState={

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,21 +1,29 @@
-import * as React from "react";
-import { useState, useEffect, useMemo, useRef } from "react";
+import React, { useCallback, useReducer, useRef } from "react";
+import { useState, useEffect } from "react";
 import { createRender, useModelState, useModel } from "@anywidget/react";
 import type { Initialize, Render } from "@anywidget/types";
 import Map from "react-map-gl/maplibre";
 import DeckGL, { DeckGLRef } from "@deck.gl/react/typed";
-import { PolygonLayer } from "@deck.gl/layers/typed";
-import type { PickingInfo } from "@deck.gl/core/typed";
-import { MapViewState, type Layer } from "@deck.gl/core/typed";
+import { MapViewState, PickingInfo, type Layer } from "@deck.gl/core/typed";
 import { BaseLayerModel, initializeLayer } from "./model/index.js";
 import type { WidgetModel } from "@jupyter-widgets/base";
 import { initParquetWasm } from "./parquet.js";
 import { getTooltip } from "./tooltip/index.js";
-import { makePolygon, isDefined, loadChildModels } from "./util.js";
+import { isDefined, loadChildModels, rateLimit } from "./util.js";
 import { v4 as uuidv4 } from "uuid";
 import { Message } from "./types.js";
 import { flyTo } from "./actions/fly-to.js";
 import { useViewStateDebounced } from "./state";
+import * as selectors from "./reducer/selectors";
+
+import "maplibre-gl/dist/maplibre-gl.css";
+
+import {
+  ActionTypes,
+  baseInitialState,
+  MapMode,
+  reducer,
+} from "./reducer/index.js";
 
 await initParquetWasm();
 
@@ -65,23 +73,24 @@ async function getChildModelState(
 }
 
 function App() {
+  const [state, dispatch] = useReducer(reducer, baseInitialState);
+
+  const isMapHoverEnabled = selectors.isMapHoverEnabled(state);
+  const isMapClickEnabled = selectors.isMapClickEnabled(state);
+  const [justClicked, setJustClicked] = useState<boolean>(false);
+  const bboxSelectPolygonLayer = selectors.bboxSelectPolygonLayer(state);
+
   const model = useModel();
 
   const [mapStyle] = useModelState<string>("basemap_style");
   const [mapHeight] = useModelState<number>("_height");
   const [showTooltip] = useModelState<boolean>("show_tooltip");
   const [pickingRadius] = useModelState<number>("picking_radius");
-  const [boundsModel, setBoundsModel] =
-    useModelState<Array<number>>("selected_bounds");
-  const [selectionMode, setSelectionMode] = useState<boolean | string>(false);
-  const [selectionObjectCount, setSelectionObjectCount] = useState<
-    boolean | number
-  >(false);
-  const [hoverBBoxLayer, setHoverBBoxLayer] = useState<any>(false);
   const [useDevicePixels] = useModelState<number | boolean>(
     "use_device_pixels",
   );
   const [parameters] = useModelState<object>("parameters");
+  const [customAttribution] = useModelState<string>("custom_attribution");
 
   // initialViewState is the value of view_state on the Python side. This is
   // called `initial` here because it gets passed in to deck's
@@ -161,136 +170,34 @@ function App() {
     }
   }, []);
 
-  // State is an array of: [screen coordinates, geographic coordinates]
-  const [selectionStart, setSelectionStart] = useState<
-    undefined | [[number, number], number[] | undefined]
-  >();
-  const [selectionEnd, setSelectionEnd] = useState<
-    undefined | [[number, number], number[] | undefined]
-  >();
+  const onMapClickHandler = useCallback(
+    (info: PickingInfo) => {
+      if (isMapClickEnabled) {
+        // We added this flag to prevent the hover event from firing after a
+        // click event.
+        setJustClicked(true);
+        dispatch({ type: ActionTypes.MAP_CLICK_EVENT, data: info });
+        setTimeout(() => {
+          setJustClicked(false);
+        }, 100);
+      }
+    },
+    [isMapClickEnabled],
+  );
 
-  function onSelectClick() {
-    if (!selectionMode) {
-      setSelectionMode("selecting");
-    }
-    if (selectionMode === "selected") {
-      setSelectionMode(false);
-      setSelectionStart(undefined);
-      setSelectionEnd(undefined);
-    }
-  }
-
-  function onMapClick(info: PickingInfo) {
-    if (!selectionMode || selectionMode === "selected") return;
-    if (selectionStart !== undefined && selectionEnd === undefined) {
-      setSelectionEnd([[info.x, info.y], info.coordinate]);
-      const pt1 = selectionStart[0];
-      const pt2 = [info.x, info.y];
-
-      const width = Math.abs(pt2[0] - pt1[0]);
-      const height = Math.abs(pt2[1] - pt1[1]);
-      const left = Math.min(pt1[0], pt2[0]);
-      const top = Math.min(pt1[1], pt2[1]);
-      const selectedObjects = mapRef.current?.pickObjects({
-        x: left,
-        y: top,
-        width,
-        height,
-      });
-      setSelectionMode("selected");
-      setHoverBBoxLayer(false);
-      setSelectionObjectCount(selectedObjects ? selectedObjects.length : 0);
-
-      // set this to what Shapely uses to represent Bounds
-      const bounds = [
-        Math.min(pt1[0], pt2[0]),
-        Math.min(pt1[1], pt2[1]),
-        Math.max(pt1[0], pt2[0]),
-        Math.max(pt1[1], pt2[1]),
-      ];
-      setBoundsModel(bounds);
-
-      // now we need to set the selected_bounds on each layer
-      loadChildModels(model.widget_manager, childLayerIds)
-        .then((layerModels) => {
-          layerModels.forEach((layer) => {
-            layer.set("selected_bounds", bounds);
-            layer.save_changes();
-          });
-        })
-        .catch((e) => {
-          console.log("error setting selected_bounds state on layer models", e);
-        });
-    } else {
-      setSelectionStart([[info.x, info.y], info.coordinate]);
-      setSelectionEnd(undefined);
-    }
-  }
-
-  function onMapHover(hoverInfo: PickingInfo) {
-    if (selectionMode !== "selecting") return;
-    const hoverCoords = hoverInfo.coordinate;
-    if (selectionStart && hoverCoords) {
-      const pt1 = selectionStart[1];
-      const pt2 = hoverCoords;
-      if (!pt1 || !pt2) return;
-      const data = [
-        {
-          polygon: makePolygon(pt1, pt2),
-        },
-      ];
-      const bboxLayer = new PolygonLayer({
-        id: "selection-layer",
-        data,
-        filled: true,
-        getFillColor: [0, 0, 0, 50],
-        stroked: true,
-        getLineWidth: 2,
-        lineWidthUnits: "pixels",
-        makePolygon: (d) => d.polygon,
-      });
-      console.log(bboxLayer);
-      setHoverBBoxLayer(bboxLayer);
-    }
-    return;
-  }
-
-  const selectionIndicator = useMemo(() => {
-    if (!selectionMode) return undefined;
-    if (selectionStart && selectionEnd) {
-      const pt1 = selectionStart[1];
-      const pt2 = selectionEnd[1];
-      if (!pt1 || !pt2) return undefined;
-      const data = [
-        {
-          polygon: makePolygon(pt1, pt2),
-        },
-      ];
-      return new PolygonLayer({
-        id: "selection-layer",
-        data,
-        filled: true,
-        getFillColor: [0, 0, 0, 30],
-        stroked: true,
-        getLineWidth: 2,
-        lineWidthUnits: "pixels",
-        makePolygon: (d) => d.polygon,
-      });
-    } else {
-      return undefined;
-    }
-  }, [selectionStart, selectionEnd, selectionMode]);
-
-  if (selectionIndicator) {
-    layers.push(selectionIndicator);
-  }
-
-  if (hoverBBoxLayer) {
-    layers.push(hoverBBoxLayer);
-  }
+  const onMapHoverHandler = useCallback(
+    rateLimit(
+      (info: PickingInfo) =>
+        isMapHoverEnabled &&
+        !justClicked &&
+        dispatch({ type: ActionTypes.MAP_HOVER_EVENT, data: info }),
+      100,
+    ),
+    [isMapHoverEnabled, justClicked],
+  );
 
   return (
-    <div id={`map-${mapId}`} style={{ height: "100%" }}>
+    <div id={`map-${mapId}`} style={{ height: mapHeight || "100%" }}>
       <div
         style={{
           position: "absolute",
@@ -301,15 +208,13 @@ function App() {
           zIndex: "1000",
           height: "12px",
         }}
-        onClick={onSelectClick}
+        onClick={() => {
+          dispatch({ type: ActionTypes.TOGGLE_BBOX_SELECT_MODE });
+        }}
       >
-        {!selectionMode ? "Click to start selecting" : ""}
-        {selectionMode === "selecting"
-          ? "Click two points on map to draw bounding box"
-          : ""}
-        {selectionMode === "selected"
-          ? `${selectionObjectCount} objects selected. Click to Unselect.`
-          : ""}
+        {state.mapMode === MapMode.BBOX_SELECT_START
+          ? "Bbox select mode"
+          : "Pan mode"}
       </div>
       <DeckGL
         initialViewState={
@@ -320,18 +225,26 @@ function App() {
             : DEFAULT_INITIAL_VIEW_STATE
         }
         controller={true}
-        layers={layers}
+        layers={layers.concat(bboxSelectPolygonLayer)}
         // @ts-expect-error
-        getTooltip={showTooltip && getTooltip}
+        getTooltip={showTooltip && state.mapMode === MapMode.PAN && getTooltip}
         pickingRadius={pickingRadius}
-        onClick={onMapClick}
-        onHover={onMapHover}
+        onHover={onMapHoverHandler}
+        onClick={onMapClickHandler}
         ref={mapRef}
         useDevicePixels={isDefined(useDevicePixels) ? useDevicePixels : true}
         // https://deck.gl/docs/api-reference/core/deck#_typedarraymanagerprops
         _typedArrayManagerProps={{
           overAlloc: 1,
           poolSize: 0,
+        }}
+        onLoad={() => {
+          if (mapRef.current) {
+            dispatch({
+              type: ActionTypes.SET_MAP_REF,
+              data: mapRef.current,
+            });
+          }
         }}
         onViewStateChange={(event) => {
           const { viewState } = event;
@@ -346,7 +259,10 @@ function App() {
         }}
         parameters={parameters || {}}
       >
-        <Map mapStyle={mapStyle || DEFAULT_MAP_STYLE} />
+        <Map
+          mapStyle={mapStyle || DEFAULT_MAP_STYLE}
+          customAttribution={customAttribution}
+        ></Map>
       </DeckGL>
     </div>
   );

--- a/src/reducer/index.ts
+++ b/src/reducer/index.ts
@@ -1,0 +1,139 @@
+import { DeckGLRef } from "@deck.gl/react/typed";
+import { logReducer } from "./utils";
+import { PickingInfo } from "@deck.gl/core/typed";
+
+export enum ActionTypes {
+  SET_MAP_REF = "SET_MAP_REF",
+  MAP_HOVER_EVENT = "MAP_HOVER_EVENT",
+  MAP_CLICK_EVENT = "MAP_CLICK_EVENT",
+  TOGGLE_BBOX_SELECT_MODE = "TOGGLE_BBOX_SELECT_MODE",
+  UPDATE_BBOX_SELECT = "UPDATE_BBOX_SELECT",
+}
+
+export enum MapMode {
+  PAN = "pan",
+  BBOX_SELECT_START = "set-bbox-start",
+  BBOX_SELECT_UPDATE = "set-bbox-update",
+}
+
+export type Action =
+  | {
+      type: ActionTypes.SET_MAP_REF;
+      data: DeckGLRef;
+    }
+  | {
+      type: ActionTypes.MAP_CLICK_EVENT;
+      data: PickingInfo;
+    }
+  | {
+      type: ActionTypes.MAP_HOVER_EVENT;
+      data: PickingInfo;
+    }
+  | {
+      type: ActionTypes.TOGGLE_BBOX_SELECT_MODE;
+    }
+  | {
+      type: ActionTypes.UPDATE_BBOX_SELECT;
+      data: { bbox: number[] };
+    };
+
+export type State = {
+  mapRef: DeckGLRef | null;
+  mapMode: MapMode;
+  selectedObjects: PickingInfo[];
+  bboxSelectStart: number[] | undefined;
+  bboxSelectStartPixel: number[] | undefined;
+  bboxSelectEnd: number[] | undefined;
+  bboxSelectEndPixel: number[] | undefined;
+};
+
+export const baseInitialState: State = {
+  mapRef: null,
+  mapMode: MapMode.PAN,
+  selectedObjects: [],
+  bboxSelectStart: undefined,
+  bboxSelectEndPixel: undefined,
+  bboxSelectEnd: undefined,
+  bboxSelectStartPixel: undefined,
+};
+
+export const baseReducer = (
+  state: typeof baseInitialState,
+  action: Action,
+): State => {
+  switch (action.type) {
+    case ActionTypes.SET_MAP_REF:
+      return { ...state, mapRef: action.data };
+    case ActionTypes.MAP_CLICK_EVENT:
+      if (state.mapMode === MapMode.BBOX_SELECT_START) {
+        console.log(action.data);
+        return {
+          ...state,
+          mapMode: MapMode.BBOX_SELECT_UPDATE,
+          bboxSelectStart: action.data.coordinate,
+          bboxSelectStartPixel: action.data.pixel,
+        };
+      } else if (state.mapMode === MapMode.BBOX_SELECT_UPDATE) {
+        const { bboxSelectStartPixel, bboxSelectEndPixel, mapRef } = state;
+        let selectedObjects: PickingInfo[] = [];
+
+        if (bboxSelectStartPixel && bboxSelectEndPixel) {
+          const [startX, startY] = bboxSelectStartPixel;
+          const [endX, endY] = bboxSelectEndPixel;
+
+          const top = Math.min(startX, endX);
+          const left = Math.min(startY, endY);
+          const width = Math.abs(endY - startY);
+          const height = Math.abs(endX - startX);
+
+          selectedObjects =
+            mapRef?.pickObjects({
+              x: top,
+              y: left,
+              width,
+              height,
+            }) || [];
+        }
+
+        return {
+          ...state,
+          mapMode: MapMode.PAN,
+          selectedObjects,
+        };
+      }
+      return state;
+    case ActionTypes.MAP_HOVER_EVENT:
+      if (state.mapMode === MapMode.BBOX_SELECT_UPDATE) {
+        return {
+          ...state,
+          bboxSelectEnd: action.data.coordinate,
+          bboxSelectEndPixel: action.data.pixel,
+        };
+      }
+      return state;
+    case ActionTypes.TOGGLE_BBOX_SELECT_MODE:
+      const nextMapMode =
+        state.mapMode === MapMode.PAN ? MapMode.BBOX_SELECT_START : MapMode.PAN;
+
+      // Clear bbox selection if we are starting a new selection
+      if (nextMapMode === MapMode.BBOX_SELECT_START) {
+        return {
+          ...state,
+          mapMode: nextMapMode,
+          bboxSelectStart: undefined,
+          bboxSelectEnd: undefined,
+        };
+      }
+
+      return {
+        ...state,
+        mapMode: nextMapMode,
+      };
+    default:
+      return state;
+  }
+};
+
+const isLoggingEnabled = true;
+
+export const reducer = isLoggingEnabled ? logReducer(baseReducer) : baseReducer;

--- a/src/reducer/selectors.ts
+++ b/src/reducer/selectors.ts
@@ -1,0 +1,63 @@
+import memoizeOne from "memoize-one";
+import { MapMode, State } from ".";
+import { PolygonLayer } from "@deck.gl/layers/typed";
+
+/**
+ * Comparison helpers (used to memoize selectors)
+ */
+
+const compareMapMode = ([state]: [State], [nextState]: [State]) =>
+  state.mapMode === nextState.mapMode;
+
+/**
+ * Selectors
+ */
+
+export const isMapHoverEnabled = memoizeOne(
+  (state: State) => state.mapMode === MapMode.BBOX_SELECT_UPDATE,
+  compareMapMode,
+);
+
+export const isMapClickEnabled = memoizeOne(
+  (state: State) =>
+    state.mapMode === MapMode.BBOX_SELECT_START ||
+    state.mapMode === MapMode.BBOX_SELECT_UPDATE,
+  compareMapMode,
+);
+
+export const bboxSelectPolygonLayer = memoizeOne(
+  (state: State) => {
+    if (!state.bboxSelectStart || !state.bboxSelectEnd) {
+      return [];
+    }
+
+    const [x0, y0] = state.bboxSelectStart;
+    const [x1, y1] = state.bboxSelectEnd;
+
+    const polygonLayer = new PolygonLayer({
+      id: "bbox-select",
+      data: [
+        {
+          polygon: [
+            [x0, y0],
+            [x1, y0],
+            [x1, y1],
+            [x0, y1],
+          ],
+        },
+      ],
+      getPolygon: (d) => d.polygon,
+      filled: true,
+      getFillColor: [0, 0, 0, 50],
+      stroked: true,
+      getLineWidth: 2,
+      lineWidthUnits: "pixels",
+    });
+
+    return polygonLayer;
+  },
+  ([state]: [State], [nextState]: [State]) =>
+    state.mapMode === MapMode.PAN ||
+    (state.bboxSelectStart === nextState.bboxSelectStart &&
+      state.bboxSelectEnd === nextState.bboxSelectEnd),
+);

--- a/src/reducer/utils.ts
+++ b/src/reducer/utils.ts
@@ -1,7 +1,6 @@
 import { Action, baseReducer, State } from ".";
 
 export function logReducer(reducer: typeof baseReducer) {
-  console.log(process.env);
   /* eslint-disable no-console */
   return (state: State, action: Action) => {
     const nextState = reducer(state, action);

--- a/src/reducer/utils.ts
+++ b/src/reducer/utils.ts
@@ -1,0 +1,23 @@
+import { Action, baseReducer, State } from ".";
+
+export function logReducer(reducer: typeof baseReducer) {
+  console.log(process.env);
+  /* eslint-disable no-console */
+  return (state: State, action: Action) => {
+    const nextState = reducer(state, action);
+
+    console.log(state, action);
+    console.groupCollapsed(action.type);
+    console.log("%c%s", "color: gray; font-weight: bold", "prev state ", state);
+    console.log("%c%s", "color: cyan; font-weight: bold", "action ", action);
+    console.log(
+      "%c%s",
+      "color: green; font-weight: bold",
+      "next state ",
+      nextState,
+    );
+    console.groupEnd();
+    return nextState;
+  };
+  /* eslint-enable no-console */
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -35,3 +35,26 @@ export function debounce<T extends Function>(cb: T, wait = 20) {
   };
   return <T>(<any>callable);
 }
+
+/**
+ * Rate limit a function.
+ *
+ * @param cb function to rate limit
+ * @param limit number of milliseconds to wait between calls
+ * @returns the rate limited function
+ */
+export function rateLimit<T extends (...args: any[]) => void>(
+  cb: T,
+  limit: number,
+): (...args: Parameters<T>) => void {
+  let lastCall = 0;
+
+  return function (...args: Parameters<T>): void {
+    const now = Date.now();
+
+    if (now - lastCall >= limit) {
+      lastCall = now;
+      cb(...args);
+    }
+  };
+}


### PR DESCRIPTION
This is based on the WIP PR https://github.com/developmentseed/lonboard/pull/417. As this introduces considerable changes, I wanted to discuss them first before adding them to the `bbox-map-select` branch.

My main goal in this PR is to fix the bbox drawing behavior. The current implementation relies on `useState` and `useMemo`, which are hard to get right due to racing conditions with the map state and do not scale well once we start working on other data management features on the map.

In this proposed approach, we use a reducer and selectors, decoupling the application logic from the component. While this introduces some boilerplate code, the Deck.gl map works more like a presentation layer, making it more maintainable and scalable in the long run.

The bbox drawing behavior seems to be working well. The workflow is similar: click on the top-right button to start selecting, then click on the map to define the start and end points.

It is possible to inspect the selected objects by opening the browser console and looking into the application state after the final click.

I haven't implemented the selected features exchange with the Python core because it is not clear to me what is the best approach. Deck.gl's [pickObjects](https://deck.gl/docs/api-reference/core/deck#pickobjects) doesn't seem to pick all objects in the bbox. It might be because it doesn't pick occluded features. The function [pickMultipleObjects](https://deck.gl/docs/api-reference/core/deck#pickmultipleobjects) seems to be the only method that picks occluded features, but the selection area must be a circle. If we find a way to get the feature IDs, we can implement the [approach](https://github.com/developmentseed/lonboard/pull/417#issuecomment-2020508957) suggested by @kylebarron, but at the moment, the only approach seems to be passing the bbox to the Python code so it can query the features.

Other known issues in this PR that we can address in the base PR:

- Map pan drag is not disabled during bbox drawing
- Cursor should update when drawing the bbox
- Reducer logger is always on; we need to figure out the best way to disable it when not in development mode

@kylebarron @batpad please let me know your thoughts on this.