### PR TITLE
Add `ColumnLayer`

### DIFF
--- a/docs/api/layers/column-layer.md
+++ b/docs/api/layers/column-layer.md
@@ -1,0 +1,5 @@
+# ColumnLayer
+
+::: lonboard.ColumnLayer
+    options:
+      inherited_members: true

--- a/lonboard/__init__.py
+++ b/lonboard/__init__.py
@@ -8,6 +8,7 @@ from ._layer import (
     BaseLayer,
     BitmapLayer,
     BitmapTileLayer,
+    ColumnLayer,
     HeatmapLayer,
     PathLayer,
     PointCloudLayer,

--- a/lonboard/_layer.py
+++ b/lonboard/_layer.py
@@ -47,6 +47,7 @@ from lonboard.types.layer import (
     BaseLayerKwargs,
     BitmapLayerKwargs,
     BitmapTileLayerKwargs,
+    ColumnLayerKwargs,
     HeatmapLayerKwargs,
     PathLayerKwargs,
     PointCloudLayerKwargs,
@@ -656,6 +657,254 @@ class BitmapTileLayer(BaseLayer):
 
     - Type: `List[float]`, optional
     - Default: `[255, 255, 255]`
+    """
+
+
+class ColumnLayer(BaseArrowLayer):
+    """
+    The ColumnLayer renders extruded cylinders (tessellated regular polygons) at given
+    coordinates.
+    """
+
+    def __init__(
+        self,
+        *,
+        table: pa.Table,
+        _rows_per_chunk: Optional[int] = None,
+        **kwargs: Unpack[ColumnLayerKwargs],
+    ):
+        super().__init__(table=table, _rows_per_chunk=_rows_per_chunk, **kwargs)
+
+    @classmethod
+    def from_geopandas(
+        cls,
+        gdf: gpd.GeoDataFrame,
+        *,
+        auto_downcast: bool = True,
+        **kwargs: Unpack[ColumnLayerKwargs],
+    ) -> Self:
+        return super().from_geopandas(gdf=gdf, auto_downcast=auto_downcast, **kwargs)
+
+    @classmethod
+    def from_duckdb(
+        cls,
+        sql: Union[str, duckdb.DuckDBPyRelation],
+        con: Optional[duckdb.DuckDBPyConnection] = None,
+        *,
+        crs: Optional[Union[str, pyproj.CRS]] = None,
+        **kwargs: Unpack[ColumnLayerKwargs],
+    ) -> Self:
+        return super().from_duckdb(sql=sql, con=con, crs=crs, **kwargs)
+
+    _layer_type = traitlets.Unicode("column").tag(sync=True)
+
+    table = PyarrowTableTrait(allowed_geometry_types={EXTENSION_NAME.POINT})
+    """A GeoArrow table with a Point or MultiPoint column.
+
+    This is the fastest way to plot data from an existing GeoArrow source, such as
+    [geoarrow-rust](https://geoarrow.github.io/geoarrow-rs/python/latest) or
+    [geoarrow-pyarrow](https://geoarrow.github.io/geoarrow-python/main/index.html).
+
+    If you have a GeoPandas `GeoDataFrame`, use
+    [`from_geopandas`][lonboard.ScatterplotLayer.from_geopandas] instead.
+    """
+
+    disk_resolution = traitlets.Int(None, allow_none=True).tag(sync=True)
+    """
+    The number of sides to render the disk as. The disk is a regular polygon that fits
+    inside the given radius. A higher resolution will yield a smoother look close-up,
+    but also need more resources to render.
+
+    - Type: `int`, optional
+    - Default: `20`
+    """
+
+    radius = traitlets.Float(None, allow_none=True).tag(sync=True)
+    """
+    Disk size in units specified by `radius_units` (default meters).
+
+    - Type: `float`, optional
+    - Default: `1000`
+    """
+
+    angle = traitlets.Float(None, allow_none=True).tag(sync=True)
+    """
+    Disk rotation, counter-clockwise in degrees.
+
+    - Type: `float`, optional
+    - Default: `0`
+    """
+
+    offset = traitlets.Tuple(
+        traitlets.Float(), traitlets.Float(), default_value=None, allow_none=True
+    ).tag(sync=True)
+    """
+    Disk offset from the position, relative to the radius. By default, the disk is
+    centered at each position.
+
+    - Type: `tuple[float, float]`, optional
+    - Default: `(0, 0)`
+    """
+
+    coverage = traitlets.Float(None, allow_none=True).tag(sync=True)
+    """
+    Radius multiplier, between 0 - 1. The radius of the disk is calculated by
+    `coverage * radius`
+
+    - Type: `float`, optional
+    - Default: `1`
+    """
+
+    elevation_scale = traitlets.Float(None, allow_none=True).tag(sync=True)
+    """
+    Column elevation multiplier. The elevation of column is calculated by
+    `elevation_scale * get_elevation(d)`. `elevation_scale` is a handy property
+    to scale all column elevations without updating the data.
+
+    - Type: `float`, optional
+    - Default: `1`
+    """
+
+    filled = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    """
+    Whether to draw a filled column (solid fill).
+
+    - Type: `bool`, optional
+    - Default: `True`
+    """
+
+    stroked = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    """
+    Whether to draw an outline around the disks. Only applies if `extruded=False`.
+
+    - Type: `bool`, optional
+    - Default: `False`
+    """
+
+    extruded = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    """
+    Whether to extrude the columns. If set to `false`, all columns will be rendered as
+    flat polygons.
+
+    - Type: `bool`, optional
+    - Default: `True`
+    """
+
+    wireframe = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    """
+    Whether to generate a line wireframe of the column. The outline will have
+    "horizontal" lines closing the top and bottom polygons and a vertical line
+    (a "strut") for each vertex around the disk. Only applies if `extruded=True`.
+
+    - Type: `bool`, optional
+    - Default: `False`
+    """
+
+    flat_shading = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    """
+    If `True`, the vertical surfaces of the columns use [flat
+    shading](https://en.wikipedia.org/wiki/Shading#Flat_vs._smooth_shading). If `false`,
+    use smooth shading. Only effective if `extruded` is `True`.
+
+    - Type: `bool`, optional
+    - Default: `False`
+    """
+
+    radius_units = traitlets.Unicode(None, allow_none=True).tag(sync=True)
+    """
+    The units of the radius, one of `'meters'`, `'common'`, and `'pixels'`. See [unit
+    system](https://deck.gl/docs/developer-guide/coordinate-systems#supported-units).
+
+    - Type: `str`, optional
+    - Default: `'meters'`
+    """
+
+    line_width_units = traitlets.Unicode(None, allow_none=True).tag(sync=True)
+    """
+    The units of the line width, one of `'meters'`, `'common'`, and `'pixels'`. See
+    [unit
+    system](https://deck.gl/docs/developer-guide/coordinate-systems#supported-units).
+
+    - Type: `str`, optional
+    - Default: `'meters'`
+    """
+
+    line_width_scale = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
+    """
+    The line width multiplier that multiplied to all outlines if the `stroked` attribute
+    is `True`.
+
+    - Type: `float`, optional
+    - Default: `1`
+    """
+
+    line_width_min_pixels = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
+    """
+    The minimum outline width in pixels. This can be used to prevent the line from
+    getting too small when zoomed out.
+
+    - Type: `float`, optional
+    - Default: `0`
+    """
+
+    line_width_max_pixels = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
+    """
+    The maximum outline width in pixels. This can be used to prevent the line from
+    getting too big when zoomed in.
+
+    - Type: `float`, optional
+    - Default: `None`
+    """
+
+    get_fill_color = ColorAccessor(None, allow_none=True)
+    """
+    The filled color of each object in the format of `[r, g, b, [a]]`. Each channel is a
+    number between 0-255 and `a` is 255 if not supplied.
+
+    - Type: [ColorAccessor][lonboard.traits.ColorAccessor], optional
+        - If a single `list` or `tuple` is provided, it is used as the filled color for
+          all objects.
+        - If a numpy or pyarrow array is provided, each value in the array will be used
+          as the filled color for the object at the same row index.
+    - Default: `[0, 0, 0, 255]`.
+    """
+
+    get_line_color = ColorAccessor(None, allow_none=True)
+    """
+    The outline color of each object in the format of `[r, g, b, [a]]`. Each channel is
+    a number between 0-255 and `a` is 255 if not supplied.
+
+    - Type: [ColorAccessor][lonboard.traits.ColorAccessor], optional
+        - If a single `list` or `tuple` is provided, it is used as the outline color for
+          all objects.
+        - If a numpy or pyarrow array is provided, each value in the array will be used
+          as the outline color for the object at the same row index.
+    - Default: `[0, 0, 0, 255]`.
+    """
+
+    get_elevation = FloatAccessor(None, allow_none=True)
+    """
+    The elevation of each cell in meters.
+
+    Only applies if `extruded=True`.
+
+    - Type: [FloatAccessor][lonboard.traits.FloatAccessor], optional
+        - If a number is provided, it is used as the width for all polygons.
+        - If an array is provided, each value in the array will be used as the width for
+          the polygon at the same row index.
+    - Default: `1000`.
+    """
+
+    get_line_width = FloatAccessor(None, allow_none=True)
+    """
+    The width of the outline of each column, in units specified by `line_width_units`
+    (default `'meters'`). Only applies if `extruded: false` and `stroked: true`.
+
+    - Type: [FloatAccessor][lonboard.traits.FloatAccessor], optional
+        - If a number is provided, it is used as the outline width for all columns.
+        - If an array is provided, each value in the array will be used as the outline
+          width for the column at the same row index.
+    - Default: `1`.
     """
 
 

--- a/lonboard/types/layer.py
+++ b/lonboard/types/layer.py
@@ -111,6 +111,29 @@ class BitmapTileLayerKwargs(BaseLayerKwargs, total=False):
     tint_color: Sequence[IntFloat]
 
 
+class ColumnLayerKwargs(BaseLayerKwargs, total=False):
+    disk_resolution: int
+    radius: IntFloat
+    angle: IntFloat
+    offset: Tuple[IntFloat, IntFloat]
+    coverage: IntFloat
+    elevation_scale: IntFloat
+    filled: bool
+    stroked: bool
+    extruded: bool
+    wireframe: bool
+    flat_shading: bool
+    radius_units: Units
+    line_width_units: Units
+    line_width_scale: IntFloat
+    line_width_min_pixels: IntFloat
+    line_width_max_pixels: IntFloat
+    get_fill_color: ColorAccessorInput
+    get_line_color: ColorAccessorInput
+    get_elevation: FloatAccessorInput
+    get_line_width: FloatAccessorInput
+
+
 class PathLayerKwargs(BaseLayerKwargs, total=False):
     width_units: Units
     width_scale: IntFloat

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
       - Layers:
           - api/layers/bitmap-layer.md
           - api/layers/bitmap-tile-layer.md
+          - api/layers/column-layer.md
           - api/layers/heatmap-layer.md
           - api/layers/path-layer.md
           - api/layers/point-cloud-layer.md

--- a/src/model/layer.ts
+++ b/src/model/layer.ts
@@ -268,9 +268,7 @@ export class ColumnModel extends BaseArrowLayerModel {
   protected radius: GeoArrowColumnLayerProps["radius"] | null;
   protected angle: GeoArrowColumnLayerProps["angle"] | null;
 
-  // // @ts-expect-error Property 'vertices' has no initializer and is not
-  // definitely assigned in the constructor
-  // Ref https://github.com/visgl/deck.gl/pull/8453
+  // Note: not yet exposed to Python
   // protected vertices: GeoArrowColumnLayerProps["vertices"] | null;
   protected offset: GeoArrowColumnLayerProps["offset"] | null;
   protected coverage: GeoArrowColumnLayerProps["coverage"] | null;
@@ -289,6 +287,7 @@ export class ColumnModel extends BaseArrowLayerModel {
   protected lineWidthMaxPixels:
     | GeoArrowColumnLayerProps["lineWidthMaxPixels"]
     | null;
+  // Note: not yet exposed to Python
   // protected material: GeoArrowColumnLayerProps["material"] | null;
 
   protected getPosition: GeoArrowColumnLayerProps["getPosition"] | null;

--- a/src/model/layer.ts
+++ b/src/model/layer.ts
@@ -268,10 +268,10 @@ export class ColumnModel extends BaseArrowLayerModel {
   protected radius: GeoArrowColumnLayerProps["radius"] | null;
   protected angle: GeoArrowColumnLayerProps["angle"] | null;
 
-  // @ts-expect-error Property 'vertices' has no initializer and is not
+  // // @ts-expect-error Property 'vertices' has no initializer and is not
   // definitely assigned in the constructor
   // Ref https://github.com/visgl/deck.gl/pull/8453
-  protected vertices: GeoArrowColumnLayerProps["vertices"] | null;
+  // protected vertices: GeoArrowColumnLayerProps["vertices"] | null;
   protected offset: GeoArrowColumnLayerProps["offset"] | null;
   protected coverage: GeoArrowColumnLayerProps["coverage"] | null;
   protected elevationScale: GeoArrowColumnLayerProps["elevationScale"] | null;
@@ -289,7 +289,8 @@ export class ColumnModel extends BaseArrowLayerModel {
   protected lineWidthMaxPixels:
     | GeoArrowColumnLayerProps["lineWidthMaxPixels"]
     | null;
-  protected material: GeoArrowColumnLayerProps["material"] | null;
+  // protected material: GeoArrowColumnLayerProps["material"] | null;
+
   protected getPosition: GeoArrowColumnLayerProps["getPosition"] | null;
   protected getFillColor: GeoArrowColumnLayerProps["getFillColor"] | null;
   protected getLineColor: GeoArrowColumnLayerProps["getLineColor"] | null;
@@ -302,7 +303,7 @@ export class ColumnModel extends BaseArrowLayerModel {
     this.initRegularAttribute("disk_resolution", "diskResolution");
     this.initRegularAttribute("radius", "radius");
     this.initRegularAttribute("angle", "angle");
-    this.initRegularAttribute("vertices", "vertices");
+    // this.initRegularAttribute("vertices", "vertices");
     this.initRegularAttribute("offset", "offset");
     this.initRegularAttribute("coverage", "coverage");
     this.initRegularAttribute("elevation_scale", "elevationScale");
@@ -316,7 +317,7 @@ export class ColumnModel extends BaseArrowLayerModel {
     this.initRegularAttribute("line_width_scale", "lineWidthScale");
     this.initRegularAttribute("line_width_min_pixels", "lineWidthMinPixels");
     this.initRegularAttribute("line_width_max_pixels", "lineWidthMaxPixels");
-    this.initRegularAttribute("material", "material");
+    // this.initRegularAttribute("material", "material");
 
     this.initVectorizedAccessor("get_position", "getPosition");
     this.initVectorizedAccessor("get_fill_color", "getFillColor");
@@ -336,8 +337,8 @@ export class ColumnModel extends BaseArrowLayerModel {
       }),
       ...(isDefined(this.radius) && { radius: this.radius }),
       ...(isDefined(this.angle) && { angle: this.angle }),
-      ...(isDefined(this.vertices) &&
-        this.vertices !== undefined && { vertices: this.vertices }),
+      // ...(isDefined(this.vertices) &&
+      //   this.vertices !== undefined && { vertices: this.vertices }),
       ...(isDefined(this.offset) && { offset: this.offset }),
       ...(isDefined(this.coverage) && { coverage: this.coverage }),
       ...(isDefined(this.elevationScale) && {
@@ -361,7 +362,7 @@ export class ColumnModel extends BaseArrowLayerModel {
       ...(isDefined(this.lineWidthMaxPixels) && {
         lineWidthMaxPixels: this.lineWidthMaxPixels,
       }),
-      ...(isDefined(this.material) && { material: this.material }),
+      // ...(isDefined(this.material) && { material: this.material }),
       ...(isDefined(this.getPosition) && { getPosition: this.getPosition }),
       ...(isDefined(this.getFillColor) && { getFillColor: this.getFillColor }),
       ...(isDefined(this.getLineColor) && { getLineColor: this.getLineColor }),


### PR DESCRIPTION
Closes https://github.com/developmentseed/lonboard/issues/543

We already had the column layer on the JS side; so this PR only adds the Python bindings + a docs page

From @cboettig 's example in the above issue:

```py
import geopandas as gpd
DATA_URL = 'https://data.source.coop/cboettig/conservation-policy/Inflation_Reduction_Act_Projects.geojson'
df = gpd.read_file(DATA_URL)

layer = ColumnLayer.from_geopandas(
    df, 
    get_elevation=df["FUNDING_NUMERIC"], 
    get_fill_color = [255, 255, 0, 140],
    elevation_scale=.01,
    radius=10000,
    pickable=True,
    auto_highlight=True,
)

m = Map(
    layer,
    view_state={"longitude": -100, "latitude": 35, "zoom": 4, "pitch": 45, "bearing": 0},
)
m
```

<img width="1152" alt="image" src="https://github.com/user-attachments/assets/5ee95991-daa1-4c06-b246-31e1d81ad003">
<img width="1068" alt="image" src="https://github.com/user-attachments/assets/e783677a-5e25-4c89-b9ce-afc0ee9c9c16">
