### PR TITLE
Parse `geoarrow.wkt` serialized data type in input

### DIFF
--- a/lonboard/_constants.py
+++ b/lonboard/_constants.py
@@ -16,6 +16,7 @@ class EXTENSION_NAME(bytes, Enum):
     MULTILINESTRING = b"geoarrow.multilinestring"
     MULTIPOLYGON = b"geoarrow.multipolygon"
     WKB = b"geoarrow.wkb"
+    WKT = b"geoarrow.wkt"
     OGC_WKB = b"ogc.wkb"
 
     def __str__(self):

--- a/lonboard/_geoarrow/utils.py
+++ b/lonboard/_geoarrow/utils.py
@@ -1,0 +1,13 @@
+from lonboard._constants import EXTENSION_NAME
+
+
+def is_native_geoarrow(extension_type_name: bytes) -> bool:
+    """Return True if this GeoArrow column has a "native" coordinate representation
+
+    This will return false for WKB and WKT-serialized arrays.
+    """
+    return extension_type_name not in {
+        EXTENSION_NAME.WKB,
+        EXTENSION_NAME.OGC_WKB,
+        EXTENSION_NAME.WKT,
+    }

--- a/lonboard/_layer.py
+++ b/lonboard/_layer.py
@@ -32,7 +32,7 @@ from lonboard._geoarrow.ops import reproject_table
 from lonboard._geoarrow.ops.bbox import Bbox, total_bounds
 from lonboard._geoarrow.ops.centroid import WeightedCentroid, weighted_centroid
 from lonboard._geoarrow.ops.coord_layout import transpose_table
-from lonboard._geoarrow.parse_wkb import parse_wkb_table
+from lonboard._geoarrow.parse_wkb import parse_serialized_table
 from lonboard._geoarrow.sanitize import remove_extension_classes
 from lonboard._serialization import infer_rows_per_chunk
 from lonboard._utils import auto_downcast as _auto_downcast
@@ -277,7 +277,7 @@ class BaseArrowLayer(BaseLayer):
             table = pa.table(table)
 
         table = remove_extension_classes(table)
-        parsed_tables = parse_wkb_table(table)
+        parsed_tables = parse_serialized_table(table)
         assert len(parsed_tables) == 1, (
             "Mixed geometry type input not supported here. Use the top "
             "level viz() function or separate your geometry types in advanced."

--- a/lonboard/_viz.py
+++ b/lonboard/_viz.py
@@ -27,7 +27,7 @@ from numpy.typing import NDArray
 from lonboard._constants import EXTENSION_NAME
 from lonboard._geoarrow.extension_types import construct_geometry_array
 from lonboard._geoarrow.geopandas_interop import geopandas_to_geoarrow
-from lonboard._geoarrow.parse_wkb import parse_wkb_table
+from lonboard._geoarrow.parse_wkb import parse_serialized_table
 from lonboard._geoarrow.sanitize import remove_extension_classes
 from lonboard._layer import PathLayer, PolygonLayer, ScatterplotLayer
 from lonboard._map import Map
@@ -482,7 +482,7 @@ def _viz_geoarrow_table(
     polygon_kwargs: Optional[PolygonLayerKwargs] = None,
 ) -> List[Union[ScatterplotLayer, PathLayer, PolygonLayer]]:
     table = remove_extension_classes(table)
-    parsed_tables = parse_wkb_table(table)
+    parsed_tables = parse_serialized_table(table)
     if len(parsed_tables) > 1:
         output: List[Union[ScatterplotLayer, PathLayer, PolygonLayer]] = []
         for parsed_table in parsed_tables:


### PR DESCRIPTION
### Change list

- We already look for `geoarrow.wkb` (and `geoarrow.ogc_wkb`) extension names in the input table and parse those WKB columns. 
- For parity with WKB, we also check for `geoarrow.wkt`, and parse it to native coords