### PR TITLE
Add quak integration

### DIFF
--- a/examples/internet-speeds.ipynb
+++ b/examples/internet-speeds.ipynb
@@ -30,15 +30,29 @@
    "outputs": [],
    "source": [
     "from pathlib import Path\n",
+    "import pyarrow as pa\n",
     "\n",
+    "from arro3.core import Array, Table, DataType, ChunkedArray\n",
     "import geopandas as gpd\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "import shapely\n",
     "from palettable.colorbrewer.diverging import BrBG_10\n",
     "\n",
+    "import quak\n",
     "from lonboard import Map, ScatterplotLayer\n",
-    "from lonboard.colormap import apply_continuous_cmap"
+    "from lonboard.colormap import apply_continuous_cmap\n",
+    "from lonboard.layer_extension import DataFilterExtension"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1ae334fe-bb36-4ab2-9b8c-b2fe10bd4038",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sqlglot"
    ]
   },
   {
@@ -51,16 +65,8 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "c747d8b9-94b9-421a-967a-8350bf72de9a",
-   "metadata": {},
-   "source": [
-    "The URL for a single data file for mobile network speeds in the first quarter of 2019:"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "34ac8eae",
    "metadata": {},
    "outputs": [],
@@ -69,20 +75,8 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "5991ef2c-5db0-4110-b6a1-b33fcbddad0d",
-   "metadata": {},
-   "source": [
-    "The data used in this example is relatively large. In the cell below, we cache the downloading and preparation of the dataset so that it's faster to run this notebook the second time.\n",
-    "\n",
-    "We fetch two columns — `avg_d_kbps` and `tile` — from this data file directly from AWS. The `pd.read_parquet` command will perform a network request for these columns from the data file, so it may take a while on a slow network connection. `avg_d_kbps` is the average download speed for that data point in kilobits per second. `tile` is the WKT string representing a given zoom-16 Web Mercator tile.\n",
-    "\n",
-    "The `tile` column contains _strings_ representing WKT-formatted geometries. We need to parse those strings into geometries. Then for simplicity we'll convert into their centroids."
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "7c20cb4c-9746-486f-aef7-95dd2dedd6a5",
    "metadata": {},
    "outputs": [],
@@ -101,16 +95,8 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "5852aa94-2d18-4a1b-b379-be19682d57eb",
-   "metadata": {},
-   "source": [
-    "We can take a quick look at this data:"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "4b27e9a4",
    "metadata": {},
    "outputs": [
@@ -158,12 +144,12 @@
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>2381</td>\n",
-       "      <td>POINT (-160.03510 70.63357)</td>\n",
+       "      <td>POINT (-160.0351 70.63357)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>3047</td>\n",
-       "      <td>POINT (-160.03510 70.63175)</td>\n",
+       "      <td>POINT (-160.0351 70.63175)</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -174,17 +160,464 @@
        "0        5983  POINT (-160.01862 70.63722)\n",
        "1        3748  POINT (-160.04059 70.63357)\n",
        "2        3364  POINT (-160.04059 70.63175)\n",
-       "3        2381  POINT (-160.03510 70.63357)\n",
-       "4        3047  POINT (-160.03510 70.63175)"
+       "3        2381   POINT (-160.0351 70.63357)\n",
+       "4        3047   POINT (-160.0351 70.63175)"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "gdf.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "5bcebd7c-58d4-487e-b191-a27e4ffb6349",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "added_names\n",
+      "[]\n"
+     ]
+    }
+   ],
+   "source": [
+    "layer = ScatterplotLayer.from_geopandas(gdf)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "77abfe2b-8c6b-4c14-ad4a-9562feb33768",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ext = DataFilterExtension(category_size=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "3764dd90-e512-4a87-89d8-bfc90e05acab",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "calling add traits\n",
+      "{'filter_categories': <traitlets.traitlets.Union object at 0x17e5696d0>, 'filter_enabled': <traitlets.traitlets.Bool object at 0x17e505d90>, 'filter_range': <traitlets.traitlets.Union object at 0x17e569e10>, 'filter_soft_range': <traitlets.traitlets.Tuple object at 0x17e56a050>, 'filter_transform_size': <traitlets.traitlets.Bool object at 0x17e56a0d0>, 'filter_transform_color': <traitlets.traitlets.Bool object at 0x17e56a1d0>, 'get_filter_value': <lonboard.traits.FilterValueAccessor object at 0x17e56a250>, 'get_filter_category': <lonboard.traits.FilterValueAccessor object at 0x17e56a350>}\n"
+     ]
+    }
+   ],
+   "source": [
+    "layer.add_extension(ext)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "dfc39cc6-200c-4f26-ba93-a446185f0ff3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "table = layer.table\n",
+    "num_rows = table.num_rows\n",
+    "if num_rows <= np.iinfo(np.uint8).max:\n",
+    "    row_index = Array.from_numpy(np.arange(num_rows, dtype=np.uint8))\n",
+    "    filter_arr = np.ones(num_rows, dtype=np.float32)\n",
+    "elif num_rows <= np.iinfo(np.uint16).max:\n",
+    "    row_index = Array.from_numpy(np.arange(num_rows, dtype=np.uint16))\n",
+    "    filter_arr = np.ones(num_rows, dtype=np.float32)\n",
+    "elif num_rows <= np.iinfo(np.uint32).max:\n",
+    "    row_index = Array.from_numpy(np.arange(num_rows, dtype=np.uint32))\n",
+    "    filter_arr = np.ones(num_rows, dtype=np.float32)\n",
+    "else:\n",
+    "    row_index = Array.from_numpy(np.arange(num_rows, dtype=np.uint64))\n",
+    "    filter_arr = np.ones(num_rows, dtype=np.float32)\n",
+    "\n",
+    "table_with_row_index = table.append_column(\"_row_index\", ChunkedArray(row_index))\n",
+    "quak_widget = quak.Widget(table_with_row_index)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "9dee0cf6-3082-4403-92b0-124cbb99e667",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "58913ce13cef47149625f6940735e6b8",
+       "version_major": 2,
+       "version_minor": 1
+      },
+      "text/plain": [
+       "Widget(sql='SELECT * FROM \"df\"', temp_indexes=True)"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "quak_widget"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "bd4431d9-93af-492d-aa4f-e7ca5d394ed0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0c81a699d5f44adf98912538fddf2032",
+       "version_major": 2,
+       "version_minor": 1
+      },
+      "text/plain": [
+       "Map(custom_attribution='', layers=[ScatterplotLayer(extensions=[DataFilterExtension()], filter_categories=[1],…"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "a99da0b6-ce83-49d7-b7a8-85b23377dcec",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0c81a699d5f44adf98912538fddf2032",
+       "version_major": 2,
+       "version_minor": 1
+      },
+      "text/plain": [
+       "Map(custom_attribution='', layers=[ScatterplotLayer(extensions=[DataFilterExtension()], filter_categories=[1],…"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "m = Map(layer)\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "1a43a9fa-bed7-4eae-97c8-2524eda01781",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([1., 1., 1., ..., 1., 1., 1.], dtype=float32)"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "filter_arr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "e55c9d4f-26ee-45d4-a006-d2f19967ad1d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[DataFilterExtension()]"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "layer.extensions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "8b94a3ae-ba93-4e7b-9b85-f85125beb712",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# layer.extensions = [ext]\n",
+    "layer.get_filter_category = filter_arr\n",
+    "layer.filter_categories = [1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "41b96069-4bae-412f-a502-15cc1ee0da92",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def row_index_callback(change):\n",
+    "    sql = sqlglot.parse_one(quak_widget.sql, dialect=\"duckdb\")\n",
+    "    sql.set(\"expressions\", [sqlglot.column(\"_row_index\")])\n",
+    "    row_index_table = quak_widget._conn.query(sql.sql(dialect=\"duckdb\")).arrow()\n",
+    "\n",
+    "    # Reset all to 2. We don't use zero because there might be a bug with 0\n",
+    "    filter_arr[:] = 2\n",
+    "\n",
+    "    # Set the desired _row_index to 1\n",
+    "    filter_arr[row_index_table[\"_row_index\"]] = 1\n",
+    "\n",
+    "    layer.get_filter_category = filter_arr\n",
+    "\n",
+    "quak_widget.observe(row_index_callback, names=\"sql\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "ef7decf8-5d7f-49f2-be44-9a4198327cdf",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "arro3.core.Array<Float32>"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "layer.get_filter_category"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "b7ea012c-7ab8-49c6-86bc-859ee345b761",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "layer.send_state()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "0215bbce-97b3-48fb-a185-426a431b3c3a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[1]"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "layer.filter_categories"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c64b53f9-5f32-4afe-8bd0-56bd69b453c0",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "a238c681-6ebc-4977-9aef-cbd93d8a1640",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf[\"slow\"] = gdf[\"avg_d_kbps\"] < 5000"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "6e3a8ad3-af0e-45e8-b0dc-277ee2a59ccf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lonboard.layer_extension import DataFilterExtension"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "47517cd2-e886-4aeb-a266-a609c97c0cb6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ext = DataFilterExtension(category_size=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "2daf3b7c-fadb-461f-b1c1-6a834eb71df7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "28b673727f4e4506ae9d8551acbf5fab",
+       "version_major": 2,
+       "version_minor": 1
+      },
+      "text/plain": [
+       "Map(custom_attribution='', layers=[ScatterplotLayer(extensions=[DataFilterExtension()], filter_categories=[0],…"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "layer = ScatterplotLayer.from_geopandas(\n",
+    "    gdf,\n",
+    "    get_filter_category = gdf[\"slow\"].astype(np.float32),\n",
+    "    filter_categories = [0],\n",
+    "    extensions=[ext]\n",
+    "                                       )\n",
+    "m = Map(layer)\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "f6dc26f8-34ac-48f4-b3f4-2c9da083be16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "layer.filter_categories = [0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "f51b34e8-a903-4a41-a9ad-78120b7bb63d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[1]"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "layer.filter_categories"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "e93bcb7f-6de8-4eca-91fe-19febbcd5ae7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0., 1., 1., ..., 0., 0., 1.], dtype=float32)"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.array(layer.get_filter_category)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "66128647-702e-4902-a29d-4edd7c852eed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ext = DataFilterExtension(category_size=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "2aa68b6c-72a3-4e27-a98a-90b1f404a34c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "layer.extensions = [ext]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "44a4852c-385f-42da-a8a0-115c16135b9f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "layer.get_filter_category = gdf[\"slow\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "9eb20ef9-8bf7-4a1c-a6e0-9c56720d20d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "layer.filter_categories = [0]"
    ]
   },
   {
@@ -195,16 +628,6 @@
     "To ensure that this demo is snappy on most computers, we'll filter to a bounding box over Europe.\n",
     "\n",
     "If you're on a recent computer, feel free to comment out the next line."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "80326895-70ba-4f4b-a7b3-106b4bbd36d9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gdf = gdf.cx[-11.83:25.5, 34.9:59]"
    ]
   },
   {
@@ -564,7 +987,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.11.8"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/lonboard/_layer.py
+++ b/lonboard/_layer.py
@@ -102,6 +102,9 @@ class BaseLayer(BaseWidget):
             self.set_trait(prop_name, prop_value)
             added_names.append(prop_name)
 
+        print("added_names")
+        print(added_names)
+
         self.send_state(added_names)
 
     # TODO: validate that only one extension per type is included. E.g. you can't have
@@ -139,6 +142,8 @@ class BaseLayer(BaseWidget):
             # the `Widget` implementation, `send_state` will fail, even if the user
             # passes in a value, because `send_state` is called before we call
             # `super().__init__()`
+            print("calling add traits")
+            print(extension._layer_traits)
             traitlets.HasTraits.add_traits(self, **extension._layer_traits)
 
             # Note: This is part of `Widget.add_traits` (in the direct superclass) that
@@ -146,6 +151,15 @@ class BaseLayer(BaseWidget):
             for name, trait in extension._layer_traits.items():
                 if trait.get_metadata("sync"):
                     self.keys.append(name)
+
+    def add_extension(self, extension: BaseExtension):
+        if any(isinstance(ext, extension.__class__) for ext in self.extensions):
+            raise ValueError("Cannot handle multiple of the same extension")
+
+        # Maybe keep a registry of which extensions have already been added?
+        self._add_extension_traits([extension])
+
+        self.extensions.append(extension)
 
     pickable = traitlets.Bool(True).tag(sync=True)
     """

--- a/lonboard/_layer.py
+++ b/lonboard/_layer.py
@@ -47,6 +47,7 @@ from lonboard.traits import (
 
 if TYPE_CHECKING:
     import geopandas as gpd
+    import quak
 
     from lonboard.types.layer import (
         BaseLayerKwargs,
@@ -389,6 +390,12 @@ class BaseArrowLayer(BaseLayer):
             table = _from_duckdb(sql, con=con, crs=crs)
 
         return cls(table=table, **kwargs)
+
+    def quak(self) -> quak.Widget:
+        import quak
+        import sqlglot
+
+        pass
 
 
 class BitmapLayer(BaseLayer):

--- a/poetry.lock
+++ b/poetry.lock
@@ -4017,6 +4017,21 @@ files = [
 ]
 
 [[package]]
+name = "sqlglot"
+version = "25.16.0"
+description = "An easily customizable SQL parser and transpiler"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "sqlglot-25.16.0-py3-none-any.whl", hash = "sha256:508575d2b6db7edd1cdc83a147a2bdc4cea38a4b68ec1c6314065798dd830b13"},
+    {file = "sqlglot-25.16.0.tar.gz", hash = "sha256:41c32c900629e7a28dd1b0411f82d84da77732bc69b21e2308bd2b00fa04cc3a"},
+]
+
+[package.extras]
+dev = ["duckdb (>=0.6)", "maturin (>=1.4,<2.0)", "mypy", "pandas", "pandas-stubs", "pdoc", "pre-commit", "python-dateutil", "pytz", "ruff (==0.4.3)", "types-python-dateutil", "types-pytz", "typing-extensions"]
+rs = ["sqlglotrs (==0.2.9)"]
+
+[[package]]
 name = "stack-data"
 version = "0.6.3"
 description = "Extract data from python stack frames and tracebacks for informative displays"
@@ -4452,4 +4467,4 @@ geopandas = ["geopandas", "pandas", "shapely"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "b190501d7ef37ce6a1d92792f5094d08f19c209a2c9508d21917627d0a52764a"
+content-hash = "5250dda2671f246ec3173063a23c1440bec60cf8db1ec0dc1013b05d18077d7b"

--- a/poetry.lock
+++ b/poetry.lock
@@ -917,58 +917,57 @@ files = [
 
 [[package]]
 name = "duckdb"
-version = "0.10.3"
+version = "1.0.0"
 description = "DuckDB in-process database"
 optional = false
 python-versions = ">=3.7.0"
 files = [
-    {file = "duckdb-0.10.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cd25cc8d001c09a19340739ba59d33e12a81ab285b7a6bed37169655e1cefb31"},
-    {file = "duckdb-0.10.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f9259c637b917ca0f4c63887e8d9b35ec248f5d987c886dfc4229d66a791009"},
-    {file = "duckdb-0.10.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b48f5f1542f1e4b184e6b4fc188f497be8b9c48127867e7d9a5f4a3e334f88b0"},
-    {file = "duckdb-0.10.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e327f7a3951ea154bb56e3fef7da889e790bd9a67ca3c36afc1beb17d3feb6d6"},
-    {file = "duckdb-0.10.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d8b20ed67da004b4481973f4254fd79a0e5af957d2382eac8624b5c527ec48c"},
-    {file = "duckdb-0.10.3-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d37680b8d7be04e4709db3a66c8b3eb7ceba2a5276574903528632f2b2cc2e60"},
-    {file = "duckdb-0.10.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3d34b86d6a2a6dfe8bb757f90bfe7101a3bd9e3022bf19dbddfa4b32680d26a9"},
-    {file = "duckdb-0.10.3-cp310-cp310-win_amd64.whl", hash = "sha256:73b1cb283ca0f6576dc18183fd315b4e487a545667ffebbf50b08eb4e8cdc143"},
-    {file = "duckdb-0.10.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d917dde19fcec8cadcbef1f23946e85dee626ddc133e1e3f6551f15a61a03c61"},
-    {file = "duckdb-0.10.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:46757e0cf5f44b4cb820c48a34f339a9ccf83b43d525d44947273a585a4ed822"},
-    {file = "duckdb-0.10.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:338c14d8ac53ac4aa9ec03b6f1325ecfe609ceeb72565124d489cb07f8a1e4eb"},
-    {file = "duckdb-0.10.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:651fcb429602b79a3cf76b662a39e93e9c3e6650f7018258f4af344c816dab72"},
-    {file = "duckdb-0.10.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d3ae3c73b98b6215dab93cc9bc936b94aed55b53c34ba01dec863c5cab9f8e25"},
-    {file = "duckdb-0.10.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:56429b2cfe70e367fb818c2be19f59ce2f6b080c8382c4d10b4f90ba81f774e9"},
-    {file = "duckdb-0.10.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b46c02c2e39e3676b1bb0dc7720b8aa953734de4fd1b762e6d7375fbeb1b63af"},
-    {file = "duckdb-0.10.3-cp311-cp311-win_amd64.whl", hash = "sha256:bcd460feef56575af2c2443d7394d405a164c409e9794a4d94cb5fdaa24a0ba4"},
-    {file = "duckdb-0.10.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:e229a7c6361afbb0d0ab29b1b398c10921263c52957aefe3ace99b0426fdb91e"},
-    {file = "duckdb-0.10.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:732b1d3b6b17bf2f32ea696b9afc9e033493c5a3b783c292ca4b0ee7cc7b0e66"},
-    {file = "duckdb-0.10.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f5380d4db11fec5021389fb85d614680dc12757ef7c5881262742250e0b58c75"},
-    {file = "duckdb-0.10.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:468a4e0c0b13c55f84972b1110060d1b0f854ffeb5900a178a775259ec1562db"},
-    {file = "duckdb-0.10.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0fa1e7ff8d18d71defa84e79f5c86aa25d3be80d7cb7bc259a322de6d7cc72da"},
-    {file = "duckdb-0.10.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ed1063ed97c02e9cf2e7fd1d280de2d1e243d72268330f45344c69c7ce438a01"},
-    {file = "duckdb-0.10.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:22f2aad5bb49c007f3bfcd3e81fdedbc16a2ae41f2915fc278724ca494128b0c"},
-    {file = "duckdb-0.10.3-cp312-cp312-win_amd64.whl", hash = "sha256:8f9e2bb00a048eb70b73a494bdc868ce7549b342f7ffec88192a78e5a4e164bd"},
-    {file = "duckdb-0.10.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a6c2fc49875b4b54e882d68703083ca6f84b27536d57d623fc872e2f502b1078"},
-    {file = "duckdb-0.10.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a66c125d0c30af210f7ee599e7821c3d1a7e09208196dafbf997d4e0cfcb81ab"},
-    {file = "duckdb-0.10.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d99dd7a1d901149c7a276440d6e737b2777e17d2046f5efb0c06ad3b8cb066a6"},
-    {file = "duckdb-0.10.3-cp37-cp37m-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5ec3bbdb209e6095d202202893763e26c17c88293b88ef986b619e6c8b6715bd"},
-    {file = "duckdb-0.10.3-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:2b3dec4ef8ed355d7b7230b40950b30d0def2c387a2e8cd7efc80b9d14134ecf"},
-    {file = "duckdb-0.10.3-cp37-cp37m-win_amd64.whl", hash = "sha256:04129f94fb49bba5eea22f941f0fb30337f069a04993048b59e2811f52d564bc"},
-    {file = "duckdb-0.10.3-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:d75d67024fc22c8edfd47747c8550fb3c34fb1cbcbfd567e94939ffd9c9e3ca7"},
-    {file = "duckdb-0.10.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f3796e9507c02d0ddbba2e84c994fae131da567ce3d9cbb4cbcd32fadc5fbb26"},
-    {file = "duckdb-0.10.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:78e539d85ebd84e3e87ec44d28ad912ca4ca444fe705794e0de9be3dd5550c11"},
-    {file = "duckdb-0.10.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a99b67ac674b4de32073e9bc604b9c2273d399325181ff50b436c6da17bf00a"},
-    {file = "duckdb-0.10.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1209a354a763758c4017a1f6a9f9b154a83bed4458287af9f71d84664ddb86b6"},
-    {file = "duckdb-0.10.3-cp38-cp38-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3b735cea64aab39b67c136ab3a571dbf834067f8472ba2f8bf0341bc91bea820"},
-    {file = "duckdb-0.10.3-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:816ffb9f758ed98eb02199d9321d592d7a32a6cb6aa31930f4337eb22cfc64e2"},
-    {file = "duckdb-0.10.3-cp38-cp38-win_amd64.whl", hash = "sha256:1631184b94c3dc38b13bce4045bf3ae7e1b0ecbfbb8771eb8d751d8ffe1b59b3"},
-    {file = "duckdb-0.10.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:fb98c35fc8dd65043bc08a2414dd9f59c680d7e8656295b8969f3f2061f26c52"},
-    {file = "duckdb-0.10.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7e75c9f5b6a92b2a6816605c001d30790f6d67ce627a2b848d4d6040686efdf9"},
-    {file = "duckdb-0.10.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ae786eddf1c2fd003466e13393b9348a44b6061af6fe7bcb380a64cac24e7df7"},
-    {file = "duckdb-0.10.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b9387da7b7973707b0dea2588749660dd5dd724273222680e985a2dd36787668"},
-    {file = "duckdb-0.10.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:538f943bf9fa8a3a7c4fafa05f21a69539d2c8a68e557233cbe9d989ae232899"},
-    {file = "duckdb-0.10.3-cp39-cp39-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6930608f35025a73eb94252964f9f19dd68cf2aaa471da3982cf6694866cfa63"},
-    {file = "duckdb-0.10.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:03bc54a9cde5490918aad82d7d2a34290e3dfb78d5b889c6626625c0f141272a"},
-    {file = "duckdb-0.10.3-cp39-cp39-win_amd64.whl", hash = "sha256:372b6e3901d85108cafe5df03c872dfb6f0dbff66165a0cf46c47246c1957aa0"},
-    {file = "duckdb-0.10.3.tar.gz", hash = "sha256:c5bd84a92bc708d3a6adffe1f554b94c6e76c795826daaaf482afc3d9c636971"},
+    {file = "duckdb-1.0.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:4a8ce2d1f9e1c23b9bab3ae4ca7997e9822e21563ff8f646992663f66d050211"},
+    {file = "duckdb-1.0.0-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:19797670f20f430196e48d25d082a264b66150c264c1e8eae8e22c64c2c5f3f5"},
+    {file = "duckdb-1.0.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:b71c342090fe117b35d866a91ad6bffce61cd6ff3e0cff4003f93fc1506da0d8"},
+    {file = "duckdb-1.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25dd69f44ad212c35ae2ea736b0e643ea2b70f204b8dff483af1491b0e2a4cec"},
+    {file = "duckdb-1.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8da5f293ecb4f99daa9a9352c5fd1312a6ab02b464653a0c3a25ab7065c45d4d"},
+    {file = "duckdb-1.0.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3207936da9967ddbb60644ec291eb934d5819b08169bc35d08b2dedbe7068c60"},
+    {file = "duckdb-1.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:1128d6c9c33e883b1f5df6b57c1eb46b7ab1baf2650912d77ee769aaa05111f9"},
+    {file = "duckdb-1.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:02310d263474d0ac238646677feff47190ffb82544c018b2ff732a4cb462c6ef"},
+    {file = "duckdb-1.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:75586791ab2702719c284157b65ecefe12d0cca9041da474391896ddd9aa71a4"},
+    {file = "duckdb-1.0.0-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:83bb415fc7994e641344f3489e40430ce083b78963cb1057bf714ac3a58da3ba"},
+    {file = "duckdb-1.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:bee2e0b415074e84c5a2cefd91f6b5ebeb4283e7196ba4ef65175a7cef298b57"},
+    {file = "duckdb-1.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fa5a4110d2a499312609544ad0be61e85a5cdad90e5b6d75ad16b300bf075b90"},
+    {file = "duckdb-1.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5fa389e6a382d4707b5f3d1bc2087895925ebb92b77e9fe3bfb23c9b98372fdc"},
+    {file = "duckdb-1.0.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7ede6f5277dd851f1a4586b0c78dc93f6c26da45e12b23ee0e88c76519cbdbe0"},
+    {file = "duckdb-1.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0b88cdbc0d5c3e3d7545a341784dc6cafd90fc035f17b2f04bf1e870c68456e5"},
+    {file = "duckdb-1.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:fd1693cdd15375156f7fff4745debc14e5c54928589f67b87fb8eace9880c370"},
+    {file = "duckdb-1.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:c65a7fe8a8ce21b985356ee3ec0c3d3b3b2234e288e64b4cfb03356dbe6e5583"},
+    {file = "duckdb-1.0.0-cp312-cp312-macosx_12_0_universal2.whl", hash = "sha256:e5a8eda554379b3a43b07bad00968acc14dd3e518c9fbe8f128b484cf95e3d16"},
+    {file = "duckdb-1.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:a1b6acdd54c4a7b43bd7cb584975a1b2ff88ea1a31607a2b734b17960e7d3088"},
+    {file = "duckdb-1.0.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a677bb1b6a8e7cab4a19874249d8144296e6e39dae38fce66a80f26d15e670df"},
+    {file = "duckdb-1.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:752e9d412b0a2871bf615a2ede54be494c6dc289d076974eefbf3af28129c759"},
+    {file = "duckdb-1.0.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3aadb99d098c5e32d00dc09421bc63a47134a6a0de9d7cd6abf21780b678663c"},
+    {file = "duckdb-1.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83b7091d4da3e9301c4f9378833f5ffe934fb1ad2b387b439ee067b2c10c8bb0"},
+    {file = "duckdb-1.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:6a8058d0148b544694cb5ea331db44f6c2a00a7b03776cc4dd1470735c3d5ff7"},
+    {file = "duckdb-1.0.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e40cb20e5ee19d44bc66ec99969af791702a049079dc5f248c33b1c56af055f4"},
+    {file = "duckdb-1.0.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7bce1bc0de9af9f47328e24e6e7e39da30093179b1c031897c042dd94a59c8e"},
+    {file = "duckdb-1.0.0-cp37-cp37m-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8355507f7a04bc0a3666958f4414a58e06141d603e91c0fa5a7c50e49867fb6d"},
+    {file = "duckdb-1.0.0-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:39f1a46f5a45ad2886dc9b02ce5b484f437f90de66c327f86606d9ba4479d475"},
+    {file = "duckdb-1.0.0-cp37-cp37m-win_amd64.whl", hash = "sha256:a6d29ba477b27ae41676b62c8fae8d04ee7cbe458127a44f6049888231ca58fa"},
+    {file = "duckdb-1.0.0-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:1bea713c1925918714328da76e79a1f7651b2b503511498ccf5e007a7e67d49e"},
+    {file = "duckdb-1.0.0-cp38-cp38-macosx_12_0_universal2.whl", hash = "sha256:bfe67f3bcf181edbf6f918b8c963eb060e6aa26697d86590da4edc5707205450"},
+    {file = "duckdb-1.0.0-cp38-cp38-macosx_12_0_x86_64.whl", hash = "sha256:dbc6093a75242f002be1d96a6ace3fdf1d002c813e67baff52112e899de9292f"},
+    {file = "duckdb-1.0.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba1881a2b11c507cee18f8fd9ef10100be066fddaa2c20fba1f9a664245cd6d8"},
+    {file = "duckdb-1.0.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:445d0bb35087c522705c724a75f9f1c13f1eb017305b694d2686218d653c8142"},
+    {file = "duckdb-1.0.0-cp38-cp38-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:224553432e84432ffb9684f33206572477049b371ce68cc313a01e214f2fbdda"},
+    {file = "duckdb-1.0.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:d3914032e47c4e76636ad986d466b63fdea65e37be8a6dfc484ed3f462c4fde4"},
+    {file = "duckdb-1.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:af9128a2eb7e1bb50cd2c2020d825fb2946fdad0a2558920cd5411d998999334"},
+    {file = "duckdb-1.0.0-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:dd2659a5dbc0df0de68f617a605bf12fe4da85ba24f67c08730984a0892087e8"},
+    {file = "duckdb-1.0.0-cp39-cp39-macosx_12_0_universal2.whl", hash = "sha256:ac5a4afb0bc20725e734e0b2c17e99a274de4801aff0d4e765d276b99dad6d90"},
+    {file = "duckdb-1.0.0-cp39-cp39-macosx_12_0_x86_64.whl", hash = "sha256:2c5a53bee3668d6e84c0536164589d5127b23d298e4c443d83f55e4150fafe61"},
+    {file = "duckdb-1.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b980713244d7708b25ee0a73de0c65f0e5521c47a0e907f5e1b933d79d972ef6"},
+    {file = "duckdb-1.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21cbd4f9fe7b7a56eff96c3f4d6778770dd370469ca2212eddbae5dd63749db5"},
+    {file = "duckdb-1.0.0-cp39-cp39-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ed228167c5d49888c5ef36f6f9cbf65011c2daf9dcb53ea8aa7a041ce567b3e4"},
+    {file = "duckdb-1.0.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:46d8395fbcea7231fd5032a250b673cc99352fef349b718a23dea2c0dd2b8dec"},
+    {file = "duckdb-1.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:6ad1fc1a4d57e7616944166a5f9417bdbca1ea65c490797e3786e3a42e162d8a"},
+    {file = "duckdb-1.0.0.tar.gz", hash = "sha256:a2a059b77bc7d5b76ae9d88e267372deff19c291048d59450c431e166233d453"},
 ]
 
 [[package]]
@@ -2721,8 +2720,8 @@ files = [
 [package.dependencies]
 numpy = [
     {version = ">=1.20.3", markers = "python_version < \"3.10\""},
-    {version = ">=1.21.0", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
     {version = ">=1.23.2", markers = "python_version >= \"3.11\""},
+    {version = ">=1.21.0", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -3618,6 +3617,22 @@ files = [
 cffi = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
+name = "quak"
+version = "0.1.8"
+description = ""
+optional = false
+python-versions = "*"
+files = [
+    {file = "quak-0.1.8-py2.py3-none-any.whl", hash = "sha256:2063c551797a7ff2d07a41f20b5ca60ec7447f6acd4ed28a8751782669bac7f7"},
+    {file = "quak-0.1.8.tar.gz", hash = "sha256:0b285c1405f123f0f68f804b408c3fc8d2335878442f5ec93c43f2f92a2c3ee5"},
+]
+
+[package.dependencies]
+anywidget = "*"
+duckdb = ">=1.0.0"
+pyarrow = ">=16.0.0"
+
+[[package]]
 name = "referencing"
 version = "0.35.1"
 description = "JSON Referencing + Python"
@@ -4437,4 +4452,4 @@ geopandas = ["geopandas", "pandas", "shapely"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "f576a4af0e4c78d4e99c4ce4ffd7ba7f122b0071767d25f4fe2a3d31f3cebb4d"
+content-hash = "b190501d7ef37ce6a1d92792f5094d08f19c209a2c9508d21917627d0a52764a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ pyarrow = ">=14.0.1"
 pyogrio = "^0.8"
 pytest = "^7.4.2"
 quak = "^0.1.8"
+sqlglot = "^25.16.0"
 
 [tool.poetry.group.docs.dependencies]
 # We use ruff format ourselves, but mkdocstrings requires black to be installed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ cli = ["click", "pyogrio", "shapely"]
 geopandas = ["geopandas", "pandas", "shapely"]
 
 [tool.poetry.group.dev.dependencies]
-duckdb = "^0.10.2"
+duckdb = "^1"
 geoarrow-pyarrow = "^0.1.1"
 geoarrow-rust-core = "^0.2.0"
 geodatasets = "^2023.12.0"
@@ -63,6 +63,7 @@ pre-commit = "^3.4.0"
 pyarrow = ">=14.0.1"
 pyogrio = "^0.8"
 pytest = "^7.4.2"
+quak = "^0.1.8"
 
 [tool.poetry.group.docs.dependencies]
 # We use ruff format ourselves, but mkdocstrings requires black to be installed

--- a/tmp4.py
+++ b/tmp4.py
@@ -1,0 +1,60 @@
+from datetime import datetime
+
+import geodatasets
+import geopandas as gpd
+import numpy as np
+import quak
+import sqlglot
+from arro3.core import Array, ChunkedArray, DataType, Table
+
+from lonboard import PolygonLayer, viz
+
+gdf = gpd.read_file(geodatasets.get_path("nybb"))
+layer = PolygonLayer.from_geopandas(gdf)
+self = layer
+self.extensions
+
+
+def quak_fn(self: PolygonLayer) -> quak.Widget:
+    table: Table = self.table
+    num_rows = table.num_rows
+    if num_rows <= np.iinfo(np.uint8).max:
+        row_index = Array.from_numpy(np.arange(num_rows, dtype=np.uint8))
+        filter_arr = np.zeros(num_rows, dtype=np.uint8)
+    elif num_rows <= np.iinfo(np.uint16).max:
+        row_index = Array.from_numpy(np.arange(num_rows, dtype=np.uint16))
+        filter_arr = np.zeros(num_rows, dtype=np.uint16)
+    elif num_rows <= np.iinfo(np.uint32).max:
+        row_index = Array.from_numpy(np.arange(num_rows, dtype=np.uint32))
+        filter_arr = np.zeros(num_rows, dtype=np.uint32)
+    else:
+        row_index = Array.from_numpy(np.arange(num_rows, dtype=np.uint64))
+        filter_arr = np.zeros(num_rows, dtype=np.uint64)
+
+    table_with_row_index = table.append_column("_row_index", ChunkedArray(row_index))
+    quak_widget = quak.Widget(table_with_row_index)
+
+    test = None
+
+    def row_index_callback(change):
+        global test
+        test = change
+
+        sql = sqlglot.parse_one(quak_widget.sql, dialect="duckdb")
+        sql.set("expressions", [sqlglot.column("_row_index")])
+        row_index_table = quak_widget._conn.query(sql.sql(dialect="duckdb")).arrow()
+
+        # Reset all to zero
+        filter_arr[:] = 0
+
+        # Set the desired _row_index to 1
+        filter_arr[row_index_table["_row_index"]] = 1
+
+    quak_widget.observe(row_index_callback, names="sql")
+
+    test
+
+
+m = viz(gdf)
+m
+table = m.layers[0].table


### PR DESCRIPTION
Learnings so far:

- deck.gl crashed when I supplied a column that was either 0 or 1, but it seems to work fine when it's either 1 or 2. This function https://github.com/visgl/deck.gl/blob/fdbb88a0c0cd662e95f5b6a84a36ec13ab9cc5d9/modules/extensions/src/data-filter/data-filter-extension.ts#L393-L408 is erroring with an invalid attempt to access `0`.
- I need to make sure the extension is correctly added to the layer, and that the extension's added traits are correctly initialized.
- It would be ideal if we could debounce this a bit. I suppose we could have a global variable of "last quak update", and then at the start of this `observe` callback, we can check if the time is within a certain amount of time since the last update? Not sure how that would work.