### PR TITLE
Manage arrow rechunking

### DIFF
--- a/lonboard/_base.py
+++ b/lonboard/_base.py
@@ -37,5 +37,7 @@ class BaseAnyWidget(AnyWidget):
 
 
 class BaseExtension(BaseWidget):
+    _extension_type: traitlets.Unicode
+
     _layer_traits: Dict[str, traitlets.TraitType] = {}
     """Traits from this extension to dynamically assign onto a layer."""

--- a/lonboard/_geoarrow/ops/coord_layout.py
+++ b/lonboard/_geoarrow/ops/coord_layout.py
@@ -23,7 +23,7 @@ from lonboard._geoarrow.ops.reproject import (
 from lonboard._utils import get_geometry_column_index
 
 
-def transpose_table(
+def make_geometry_interleaved(
     table: Table,
 ) -> Table:
     """Convert geometry columns in table to interleaved coordinate layout"""

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -187,6 +187,7 @@ def test_layer_arrow_rechunking_geodataframe():
     assert np.array_equal(chunk_lengths, batch_lengths)
 
 
+@pytest.mark.skipif(not compat.HAS_SHAPELY, reason="shapely not available")
 def test_layer_arrow_rechunking_arrow_input():
     path = geodatasets.get_path("naturalearth.land")
     meta, table = read_arrow(path)

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -163,10 +163,11 @@ def test_float_accessor_validation_type():
     FloatAccessorWidget(value=pd.Series([2, 3, 4], dtype=np.float32))
     FloatAccessorWidget(value=pd.Series([2, 3, 4], dtype=np.float64))
 
-    # Must be floating-point array type
+    # Must be numeric array type
     with pytest.raises(TraitError):
-        FloatAccessorWidget(value=pa.array(np.array([2, 3, 4])))
+        FloatAccessorWidget(value=pa.array(np.array(["2", "3", "4"])))
 
+    FloatAccessorWidget(value=pa.array(np.array([2, 3, 4], dtype=np.int32)))
     FloatAccessorWidget(value=pa.array(np.array([2, 3, 4], dtype=np.float32)))
     FloatAccessorWidget(value=pa.array(np.array([2, 3, 4], dtype=np.float64)))
 


### PR DESCRIPTION
### Change list

- Rechunk all non-scalar accessor data to match the chunking of the main table.
- All Arrow accessors are stored as `arro3.core.ChunkedArray`. Bare arrays are never stored.

Closes https://github.com/developmentseed/lonboard/issues/611

cc @abarciauskas-bgse since you commented on https://github.com/developmentseed/lonboard/issues/611