### PR TITLE
Remove arrow workaround from overture maps example

### DIFF
--- a/examples/overture-maps.ipynb
+++ b/examples/overture-maps.ipynb
@@ -90,10 +90,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "table = overturemaps.record_batch_reader(\"building\", bbox).read_all()\n",
-    "\n",
-    "# Temporarily required as of Lonboard 0.8 to avoid a Lonboard bug\n",
-    "table = table.combine_chunks()"
+    "table = overturemaps.record_batch_reader(\"building\", bbox).read_all()"
    ]
   },
   {
@@ -232,7 +229,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.11.8"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/poetry.lock
+++ b/poetry.lock
@@ -2972,8 +2972,8 @@ files = [
 [package.dependencies]
 numpy = [
     {version = ">=1.20.3", markers = "python_version < \"3.10\""},
-    {version = ">=1.21.0", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
     {version = ">=1.23.2", markers = "python_version >= \"3.11\""},
+    {version = ">=1.21.0", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"


### PR DESCRIPTION
Closes https://github.com/developmentseed/lonboard/issues/482, originally fixed by https://github.com/developmentseed/lonboard/pull/644