### PR TITLE
`import traitlets as t`

### DIFF
--- a/lonboard/_layer.py
+++ b/lonboard/_layer.py
@@ -23,6 +23,7 @@ from typing import (
 
 import ipywidgets
 import traitlets
+import traitlets as t
 from arro3.core import Table
 from arro3.core.types import ArrowStreamExportable
 
@@ -106,7 +107,7 @@ class BaseLayer(BaseWidget):
 
     # TODO: validate that only one extension per type is included. E.g. you can't have
     # two data filter extensions.
-    extensions = VariableLengthTuple(traitlets.Instance(BaseExtension)).tag(
+    extensions = VariableLengthTuple(t.Instance(BaseExtension)).tag(
         sync=True, **ipywidgets.widget_serialization
     )
     """
@@ -187,7 +188,7 @@ class BaseLayer(BaseWidget):
 
     #     self.send_state(added_names + ["extensions"])
 
-    pickable = traitlets.Bool(True).tag(sync=True)
+    pickable = t.Bool(True).tag(sync=True)
     """
     Whether the layer responds to mouse pointer picking events.
 
@@ -203,7 +204,7 @@ class BaseLayer(BaseWidget):
     - Default: `True`
     """
 
-    visible = traitlets.Bool(True).tag(sync=True)
+    visible = t.Bool(True).tag(sync=True)
     """
     Whether the layer is visible.
 
@@ -218,7 +219,7 @@ class BaseLayer(BaseWidget):
     - Default: `True`
     """
 
-    opacity = traitlets.Float(1, min=0, max=1).tag(sync=True)
+    opacity = t.Float(1, min=0, max=1).tag(sync=True)
     """
     The opacity of the layer.
 
@@ -226,7 +227,7 @@ class BaseLayer(BaseWidget):
     - Default: `1`
     """
 
-    auto_highlight = traitlets.Bool(False).tag(sync=True)
+    auto_highlight = t.Bool(False).tag(sync=True)
     """
     When true, the current object pointed to by the mouse pointer (when hovered over) is
     highlighted with `highlightColor`.
@@ -237,13 +238,8 @@ class BaseLayer(BaseWidget):
     - Default: `False`
     """
 
-    selected_bounds = traitlets.Tuple(
-        traitlets.Float(),
-        traitlets.Float(),
-        traitlets.Float(),
-        traitlets.Float(),
-        allow_none=True,
-        default_value=None,
+    selected_bounds = t.Tuple(
+        t.Float(), t.Float(), t.Float(), t.Float(), allow_none=True, default_value=None
     ).tag(sync=True)
     """
     Bounds selected by the user, represented as a tuple of floats ordered as
@@ -253,7 +249,7 @@ class BaseLayer(BaseWidget):
     ```
     """
 
-    selected_index = traitlets.Int(None, allow_none=True).tag(sync=True)
+    selected_index = t.Int(None, allow_none=True).tag(sync=True)
     """
     The positional index of the most-recently clicked on row of data.
 
@@ -456,19 +452,19 @@ class BitmapLayer(BaseLayer):
     def __init__(self, **kwargs: BitmapLayerKwargs):
         super().__init__(**kwargs)  # type: ignore
 
-    _layer_type = traitlets.Unicode("bitmap").tag(sync=True)
+    _layer_type = t.Unicode("bitmap").tag(sync=True)
 
-    image = traitlets.Unicode().tag(sync=True)
+    image = t.Unicode().tag(sync=True)
     """The URL to an image to display.
 
     - Type: `str`
     """
 
-    bounds = traitlets.Union(
+    bounds = t.Union(
         [
-            VariableLengthTuple(traitlets.Float(), minlen=4, maxlen=4),
+            VariableLengthTuple(t.Float(), minlen=4, maxlen=4),
             VariableLengthTuple(
-                VariableLengthTuple(traitlets.Float(), minlen=2, maxlen=2),
+                VariableLengthTuple(t.Float(), minlen=2, maxlen=2),
                 minlen=4,
                 maxlen=4,
             ),
@@ -483,7 +479,7 @@ class BitmapLayer(BaseLayer):
           `[[left, bottom], [left, top], [right, top], [right, bottom]]`.
     """
 
-    desaturate = traitlets.Float(0, min=0, max=1).tag(sync=True)
+    desaturate = t.Float(0, min=0, max=1).tag(sync=True)
     """The desaturation of the bitmap. Between `[0, 1]`.
 
     - Type: `float`, optional
@@ -491,7 +487,7 @@ class BitmapLayer(BaseLayer):
     """
 
     transparent_color = VariableLengthTuple(
-        traitlets.Float(), default_value=None, allow_none=True, minlen=3, maxlen=4
+        t.Float(), default_value=None, allow_none=True, minlen=3, maxlen=4
     )
     """The color to use for transparent pixels, in `[r, g, b, a]`.
 
@@ -500,7 +496,7 @@ class BitmapLayer(BaseLayer):
     """
 
     tint_color = VariableLengthTuple(
-        traitlets.Float(), default_value=None, allow_none=True, minlen=3, maxlen=4
+        t.Float(), default_value=None, allow_none=True, minlen=3, maxlen=4
     )
     """The color to tint the bitmap by, in `[r, g, b]`.
 
@@ -559,11 +555,11 @@ class BitmapTileLayer(BaseLayer):
     def __init__(self, **kwargs: BitmapTileLayerKwargs):
         super().__init__(**kwargs)  # type: ignore
 
-    _layer_type = traitlets.Unicode("bitmap-tile").tag(sync=True)
+    _layer_type = t.Unicode("bitmap-tile").tag(sync=True)
 
-    data = traitlets.Union(
-        [traitlets.Unicode(), VariableLengthTuple(traitlets.Unicode(), minlen=1)]
-    ).tag(sync=True)
+    data = t.Union([t.Unicode(), VariableLengthTuple(t.Unicode(), minlen=1)]).tag(
+        sync=True
+    )
     """
     Either a URL template or an array of URL templates from which the tile data should
     be loaded.
@@ -577,7 +573,7 @@ class BitmapTileLayer(BaseLayer):
     balanced among the endpoints, based on the tile index.
     """
 
-    tile_size = traitlets.Int(None, allow_none=True).tag(sync=True)
+    tile_size = t.Int(None, allow_none=True).tag(sync=True)
     """
     The pixel dimension of the tiles, usually a power of 2.
 
@@ -589,7 +585,7 @@ class BitmapTileLayer(BaseLayer):
     - Default: `512`
     """
 
-    zoom_offset = traitlets.Int(None, allow_none=True).tag(sync=True)
+    zoom_offset = t.Int(None, allow_none=True).tag(sync=True)
     """
     This offset changes the zoom level at which the tiles are fetched. Needs to be an
     integer.
@@ -598,7 +594,7 @@ class BitmapTileLayer(BaseLayer):
     - Default: `0`
     """
 
-    max_zoom = traitlets.Int(None, allow_none=True).tag(sync=True)
+    max_zoom = t.Int(None, allow_none=True).tag(sync=True)
     """
     The max zoom level of the layer's data. When overzoomed (i.e. `zoom > max_zoom`),
     tiles from this level will be displayed.
@@ -607,7 +603,7 @@ class BitmapTileLayer(BaseLayer):
     - Default: `None`
     """
 
-    min_zoom = traitlets.Int(None, allow_none=True).tag(sync=True)
+    min_zoom = t.Int(None, allow_none=True).tag(sync=True)
     """
     The min zoom level of the layer's data. When underzoomed (i.e. `zoom < min_zoom`),
     the layer will not display any tiles unless `extent` is defined, to avoid issuing
@@ -618,7 +614,7 @@ class BitmapTileLayer(BaseLayer):
     """
 
     extent = VariableLengthTuple(
-        traitlets.Float(), minlen=4, maxlen=4, allow_none=True, default_value=None
+        t.Float(), minlen=4, maxlen=4, allow_none=True, default_value=None
     ).tag(sync=True)
     """
     The bounding box of the layer's data, in the form of `[min_x, min_y, max_x, max_y]`.
@@ -629,7 +625,7 @@ class BitmapTileLayer(BaseLayer):
     - Default: `None`
     """
 
-    max_cache_size = traitlets.Int(None, allow_none=True).tag(sync=True)
+    max_cache_size = t.Int(None, allow_none=True).tag(sync=True)
     """
     The maximum number of tiles that can be cached. The tile cache keeps loaded tiles in
     memory even if they are no longer visible. It reduces the need to re-download the
@@ -644,11 +640,11 @@ class BitmapTileLayer(BaseLayer):
     """
 
     # TODO: Not sure if `getTileData` returns a `byteLength`?
-    # max_cache_byte_size = traitlets.Int(None, allow_none=True).tag(sync=True)
+    # max_cache_byte_size = t.Int(None, allow_none=True).tag(sync=True)
     # """
     # """
 
-    refinement_strategy = traitlets.Unicode(None, allow_none=True).tag(sync=True)
+    refinement_strategy = t.Unicode(None, allow_none=True).tag(sync=True)
     """How the tile layer refines the visibility of tiles.
 
     When zooming in and out, if the layer only shows tiles from the current zoom level,
@@ -669,7 +665,7 @@ class BitmapTileLayer(BaseLayer):
     - Default: `"best-available"`
     """
 
-    max_requests = traitlets.Int(None, allow_none=True).tag(sync=True)
+    max_requests = t.Int(None, allow_none=True).tag(sync=True)
     """The maximum number of concurrent data fetches.
 
     If <= 0, no throttling will occur, and `get_tile_data` may be called an unlimited
@@ -693,7 +689,7 @@ class BitmapTileLayer(BaseLayer):
     how long the tile was visible, and may increase server load.
     """
 
-    desaturate = traitlets.Float(0, min=0, max=1).tag(sync=True)
+    desaturate = t.Float(0, min=0, max=1).tag(sync=True)
     """The desaturation of the bitmap. Between `[0, 1]`.
 
     - Type: `float`, optional
@@ -701,7 +697,7 @@ class BitmapTileLayer(BaseLayer):
     """
 
     transparent_color = VariableLengthTuple(
-        traitlets.Float(), default_value=None, allow_none=True, minlen=3, maxlen=4
+        t.Float(), default_value=None, allow_none=True, minlen=3, maxlen=4
     )
     """The color to use for transparent pixels, in `[r, g, b, a]`.
 
@@ -710,7 +706,7 @@ class BitmapTileLayer(BaseLayer):
     """
 
     tint_color = VariableLengthTuple(
-        traitlets.Float(), default_value=None, allow_none=True, minlen=3, maxlen=4
+        t.Float(), default_value=None, allow_none=True, minlen=3, maxlen=4
     )
     """The color to tint the bitmap by, in `[r, g, b]`.
 
@@ -755,7 +751,7 @@ class ColumnLayer(BaseArrowLayer):
     ) -> Self:
         return super().from_duckdb(sql=sql, con=con, crs=crs, **kwargs)
 
-    _layer_type = traitlets.Unicode("column").tag(sync=True)
+    _layer_type = t.Unicode("column").tag(sync=True)
 
     table = ArrowTableTrait(allowed_geometry_types={EXTENSION_NAME.POINT})
     """A GeoArrow table with a Point or MultiPoint column.
@@ -768,7 +764,7 @@ class ColumnLayer(BaseArrowLayer):
     [`from_geopandas`][lonboard.ScatterplotLayer.from_geopandas] instead.
     """
 
-    disk_resolution = traitlets.Int(None, allow_none=True).tag(sync=True)
+    disk_resolution = t.Int(None, allow_none=True).tag(sync=True)
     """
     The number of sides to render the disk as. The disk is a regular polygon that fits
     inside the given radius. A higher resolution will yield a smoother look close-up,
@@ -778,7 +774,7 @@ class ColumnLayer(BaseArrowLayer):
     - Default: `20`
     """
 
-    radius = traitlets.Float(None, allow_none=True).tag(sync=True)
+    radius = t.Float(None, allow_none=True).tag(sync=True)
     """
     Disk size in units specified by `radius_units` (default meters).
 
@@ -786,7 +782,7 @@ class ColumnLayer(BaseArrowLayer):
     - Default: `1000`
     """
 
-    angle = traitlets.Float(None, allow_none=True).tag(sync=True)
+    angle = t.Float(None, allow_none=True).tag(sync=True)
     """
     Disk rotation, counter-clockwise in degrees.
 
@@ -794,9 +790,9 @@ class ColumnLayer(BaseArrowLayer):
     - Default: `0`
     """
 
-    offset = traitlets.Tuple(
-        traitlets.Float(), traitlets.Float(), default_value=None, allow_none=True
-    ).tag(sync=True)
+    offset = t.Tuple(t.Float(), t.Float(), default_value=None, allow_none=True).tag(
+        sync=True
+    )
     """
     Disk offset from the position, relative to the radius. By default, the disk is
     centered at each position.
@@ -805,7 +801,7 @@ class ColumnLayer(BaseArrowLayer):
     - Default: `(0, 0)`
     """
 
-    coverage = traitlets.Float(None, allow_none=True).tag(sync=True)
+    coverage = t.Float(None, allow_none=True).tag(sync=True)
     """
     Radius multiplier, between 0 - 1. The radius of the disk is calculated by
     `coverage * radius`
@@ -814,7 +810,7 @@ class ColumnLayer(BaseArrowLayer):
     - Default: `1`
     """
 
-    elevation_scale = traitlets.Float(None, allow_none=True).tag(sync=True)
+    elevation_scale = t.Float(None, allow_none=True).tag(sync=True)
     """
     Column elevation multiplier. The elevation of column is calculated by
     `elevation_scale * get_elevation(d)`. `elevation_scale` is a handy property
@@ -824,7 +820,7 @@ class ColumnLayer(BaseArrowLayer):
     - Default: `1`
     """
 
-    filled = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    filled = t.Bool(None, allow_none=True).tag(sync=True)
     """
     Whether to draw a filled column (solid fill).
 
@@ -832,7 +828,7 @@ class ColumnLayer(BaseArrowLayer):
     - Default: `True`
     """
 
-    stroked = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    stroked = t.Bool(None, allow_none=True).tag(sync=True)
     """
     Whether to draw an outline around the disks. Only applies if `extruded=False`.
 
@@ -840,7 +836,7 @@ class ColumnLayer(BaseArrowLayer):
     - Default: `False`
     """
 
-    extruded = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    extruded = t.Bool(None, allow_none=True).tag(sync=True)
     """
     Whether to extrude the columns. If set to `false`, all columns will be rendered as
     flat polygons.
@@ -849,7 +845,7 @@ class ColumnLayer(BaseArrowLayer):
     - Default: `True`
     """
 
-    wireframe = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    wireframe = t.Bool(None, allow_none=True).tag(sync=True)
     """
     Whether to generate a line wireframe of the column. The outline will have
     "horizontal" lines closing the top and bottom polygons and a vertical line
@@ -859,7 +855,7 @@ class ColumnLayer(BaseArrowLayer):
     - Default: `False`
     """
 
-    flat_shading = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    flat_shading = t.Bool(None, allow_none=True).tag(sync=True)
     """
     If `True`, the vertical surfaces of the columns use [flat
     shading](https://en.wikipedia.org/wiki/Shading#Flat_vs._smooth_shading). If `false`,
@@ -869,7 +865,7 @@ class ColumnLayer(BaseArrowLayer):
     - Default: `False`
     """
 
-    radius_units = traitlets.Unicode(None, allow_none=True).tag(sync=True)
+    radius_units = t.Unicode(None, allow_none=True).tag(sync=True)
     """
     The units of the radius, one of `'meters'`, `'common'`, and `'pixels'`. See [unit
     system](https://deck.gl/docs/developer-guide/coordinate-systems#supported-units).
@@ -878,7 +874,7 @@ class ColumnLayer(BaseArrowLayer):
     - Default: `'meters'`
     """
 
-    line_width_units = traitlets.Unicode(None, allow_none=True).tag(sync=True)
+    line_width_units = t.Unicode(None, allow_none=True).tag(sync=True)
     """
     The units of the line width, one of `'meters'`, `'common'`, and `'pixels'`. See
     [unit
@@ -888,7 +884,7 @@ class ColumnLayer(BaseArrowLayer):
     - Default: `'meters'`
     """
 
-    line_width_scale = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
+    line_width_scale = t.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     The line width multiplier that multiplied to all outlines if the `stroked` attribute
     is `True`.
@@ -897,7 +893,7 @@ class ColumnLayer(BaseArrowLayer):
     - Default: `1`
     """
 
-    line_width_min_pixels = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
+    line_width_min_pixels = t.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     The minimum outline width in pixels. This can be used to prevent the line from
     getting too small when zoomed out.
@@ -906,7 +902,7 @@ class ColumnLayer(BaseArrowLayer):
     - Default: `0`
     """
 
-    line_width_max_pixels = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
+    line_width_max_pixels = t.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     The maximum outline width in pixels. This can be used to prevent the line from
     getting too big when zoomed in.
@@ -1042,7 +1038,7 @@ class PolygonLayer(BaseArrowLayer):
     ) -> Self:
         return super().from_duckdb(sql=sql, con=con, crs=crs, **kwargs)
 
-    _layer_type = traitlets.Unicode("polygon").tag(sync=True)
+    _layer_type = t.Unicode("polygon").tag(sync=True)
 
     table = ArrowTableTrait(
         allowed_geometry_types={EXTENSION_NAME.POLYGON, EXTENSION_NAME.MULTIPOLYGON}
@@ -1057,7 +1053,7 @@ class PolygonLayer(BaseArrowLayer):
     [`from_geopandas`][lonboard.PolygonLayer.from_geopandas] instead.
     """
 
-    stroked = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    stroked = t.Bool(None, allow_none=True).tag(sync=True)
     """Whether to draw an outline around the polygon (solid fill).
 
     Note that both the outer polygon as well the outlines of any holes will be drawn.
@@ -1066,7 +1062,7 @@ class PolygonLayer(BaseArrowLayer):
     - Default: `True`
     """
 
-    filled = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    filled = t.Bool(None, allow_none=True).tag(sync=True)
     """Whether to draw a filled polygon (solid fill).
 
     Note that only the area between the outer polygon and any holes will be filled.
@@ -1075,7 +1071,7 @@ class PolygonLayer(BaseArrowLayer):
     - Default: `True`
     """
 
-    extruded = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    extruded = t.Bool(None, allow_none=True).tag(sync=True)
     """Whether to extrude the polygons.
 
     Based on the elevations provided by the `getElevation` accessor.
@@ -1087,7 +1083,7 @@ class PolygonLayer(BaseArrowLayer):
     - Default: `False`
     """
 
-    wireframe = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    wireframe = t.Bool(None, allow_none=True).tag(sync=True)
     """
     Whether to generate a line wireframe of the polygon. The outline will have
     "horizontal" lines closing the top and bottom polygons and a vertical line
@@ -1103,7 +1099,7 @@ class PolygonLayer(BaseArrowLayer):
       with the same data if you want a combined rendering effect.
     """
 
-    elevation_scale = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
+    elevation_scale = t.Float(None, allow_none=True, min=0).tag(sync=True)
     """Elevation multiplier.
 
     The final elevation is calculated by `elevationScale * getElevation(d)`.
@@ -1114,7 +1110,7 @@ class PolygonLayer(BaseArrowLayer):
     - Default: `1`
     """
 
-    line_width_units = traitlets.Unicode(None, allow_none=True).tag(sync=True)
+    line_width_units = t.Unicode(None, allow_none=True).tag(sync=True)
     """
     The units of the line width, one of `'meters'`, `'common'`, and `'pixels'`. See
     [unit
@@ -1124,7 +1120,7 @@ class PolygonLayer(BaseArrowLayer):
     - Default: `'meters'`
     """
 
-    line_width_scale = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
+    line_width_scale = t.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     The line width multiplier that multiplied to all outlines of `Polygon` and
     `MultiPolygon` features if the `stroked` attribute is true.
@@ -1133,7 +1129,7 @@ class PolygonLayer(BaseArrowLayer):
     - Default: `1`
     """
 
-    line_width_min_pixels = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
+    line_width_min_pixels = t.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     The minimum line width in pixels. This can be used to prevent the line from getting
     too small when zoomed out.
@@ -1142,7 +1138,7 @@ class PolygonLayer(BaseArrowLayer):
     - Default: `0`
     """
 
-    line_width_max_pixels = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
+    line_width_max_pixels = t.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     The maximum line width in pixels. This can be used to prevent the line from getting
     too big when zoomed in.
@@ -1151,14 +1147,14 @@ class PolygonLayer(BaseArrowLayer):
     - Default: `None`
     """
 
-    line_joint_rounded = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    line_joint_rounded = t.Bool(None, allow_none=True).tag(sync=True)
     """Type of joint. If `true`, draw round joints. Otherwise draw miter joints.
 
     - Type: `bool`, optional
     - Default: `False`
     """
 
-    line_miter_limit = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
+    line_miter_limit = t.Float(None, allow_none=True, min=0).tag(sync=True)
     """The maximum extent of a joint in ratio to the stroke width.
 
     Only works if `line_joint_rounded` is false.
@@ -1287,7 +1283,7 @@ class ScatterplotLayer(BaseArrowLayer):
     ) -> Self:
         return super().from_duckdb(sql=sql, con=con, crs=crs, **kwargs)
 
-    _layer_type = traitlets.Unicode("scatterplot").tag(sync=True)
+    _layer_type = t.Unicode("scatterplot").tag(sync=True)
 
     table = ArrowTableTrait(
         allowed_geometry_types={EXTENSION_NAME.POINT, EXTENSION_NAME.MULTIPOINT}
@@ -1302,7 +1298,7 @@ class ScatterplotLayer(BaseArrowLayer):
     [`from_geopandas`][lonboard.ScatterplotLayer.from_geopandas] instead.
     """
 
-    radius_units = traitlets.Unicode(None, allow_none=True).tag(sync=True)
+    radius_units = t.Unicode(None, allow_none=True).tag(sync=True)
     """
     The units of the radius, one of `'meters'`, `'common'`, and `'pixels'`. See [unit
     system](https://deck.gl/docs/developer-guide/coordinate-systems#supported-units).
@@ -1311,7 +1307,7 @@ class ScatterplotLayer(BaseArrowLayer):
     - Default: `'meters'`
     """
 
-    radius_scale = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
+    radius_scale = t.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     A global radius multiplier for all points.
 
@@ -1319,7 +1315,7 @@ class ScatterplotLayer(BaseArrowLayer):
     - Default: `1`
     """
 
-    radius_min_pixels = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
+    radius_min_pixels = t.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     The minimum radius in pixels. This can be used to prevent the circle from getting
     too small when zoomed out.
@@ -1328,7 +1324,7 @@ class ScatterplotLayer(BaseArrowLayer):
     - Default: `0`
     """
 
-    radius_max_pixels = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
+    radius_max_pixels = t.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     The maximum radius in pixels. This can be used to prevent the circle from getting
     too big when zoomed in.
@@ -1337,7 +1333,7 @@ class ScatterplotLayer(BaseArrowLayer):
     - Default: `None`
     """
 
-    line_width_units = traitlets.Unicode(None, allow_none=True).tag(sync=True)
+    line_width_units = t.Unicode(None, allow_none=True).tag(sync=True)
     """
     The units of the line width, one of `'meters'`, `'common'`, and `'pixels'`. See
     [unit
@@ -1347,7 +1343,7 @@ class ScatterplotLayer(BaseArrowLayer):
     - Default: `'meters'`
     """
 
-    line_width_scale = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
+    line_width_scale = t.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     A global line width multiplier for all points.
 
@@ -1355,7 +1351,7 @@ class ScatterplotLayer(BaseArrowLayer):
     - Default: `1`
     """
 
-    line_width_min_pixels = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
+    line_width_min_pixels = t.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     The minimum line width in pixels. This can be used to prevent the stroke from
     getting too thin when zoomed out.
@@ -1364,7 +1360,7 @@ class ScatterplotLayer(BaseArrowLayer):
     - Default: `0`
     """
 
-    line_width_max_pixels = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
+    line_width_max_pixels = t.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     The maximum line width in pixels. This can be used to prevent the stroke from
     getting too thick when zoomed in.
@@ -1373,7 +1369,7 @@ class ScatterplotLayer(BaseArrowLayer):
     - Default: `None`
     """
 
-    stroked = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    stroked = t.Bool(None, allow_none=True).tag(sync=True)
     """
     Draw the outline of points.
 
@@ -1381,7 +1377,7 @@ class ScatterplotLayer(BaseArrowLayer):
     - Default: `False`
     """
 
-    filled = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    filled = t.Bool(None, allow_none=True).tag(sync=True)
     """
     Draw the filled area of points.
 
@@ -1389,7 +1385,7 @@ class ScatterplotLayer(BaseArrowLayer):
     - Default: `True`
     """
 
-    billboard = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    billboard = t.Bool(None, allow_none=True).tag(sync=True)
     """
     If `True`, rendered circles always face the camera. If `False` circles face up (i.e.
     are parallel with the ground plane).
@@ -1398,7 +1394,7 @@ class ScatterplotLayer(BaseArrowLayer):
     - Default: `False`
     """
 
-    antialiasing = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    antialiasing = t.Bool(None, allow_none=True).tag(sync=True)
     """
     If `True`, circles are rendered with smoothed edges. If `False`, circles are
     rendered with rough edges. Antialiasing can cause artifacts on edges of overlapping
@@ -1529,7 +1525,7 @@ class PathLayer(BaseArrowLayer):
     ) -> Self:
         return super().from_duckdb(sql=sql, con=con, crs=crs, **kwargs)
 
-    _layer_type = traitlets.Unicode("path").tag(sync=True)
+    _layer_type = t.Unicode("path").tag(sync=True)
 
     table = ArrowTableTrait(
         allowed_geometry_types={
@@ -1547,7 +1543,7 @@ class PathLayer(BaseArrowLayer):
     [`from_geopandas`][lonboard.PathLayer.from_geopandas] instead.
     """
 
-    width_units = traitlets.Unicode(None, allow_none=True).tag(sync=True)
+    width_units = t.Unicode(None, allow_none=True).tag(sync=True)
     """
     The units of the line width, one of `'meters'`, `'common'`, and `'pixels'`. See
     [unit
@@ -1557,7 +1553,7 @@ class PathLayer(BaseArrowLayer):
     - Default: `'meters'`
     """
 
-    width_scale = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
+    width_scale = t.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     The path width multiplier that multiplied to all paths.
 
@@ -1565,7 +1561,7 @@ class PathLayer(BaseArrowLayer):
     - Default: `1`
     """
 
-    width_min_pixels = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
+    width_min_pixels = t.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     The minimum path width in pixels. This prop can be used to prevent the path from
     getting too thin when zoomed out.
@@ -1574,7 +1570,7 @@ class PathLayer(BaseArrowLayer):
     - Default: `0`
     """
 
-    width_max_pixels = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
+    width_max_pixels = t.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     The maximum path width in pixels. This prop can be used to prevent the path from
     getting too thick when zoomed in.
@@ -1583,7 +1579,7 @@ class PathLayer(BaseArrowLayer):
     - Default: `None`
     """
 
-    joint_rounded = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    joint_rounded = t.Bool(None, allow_none=True).tag(sync=True)
     """
     Type of joint. If `True`, draw round joints. Otherwise draw miter joints.
 
@@ -1591,7 +1587,7 @@ class PathLayer(BaseArrowLayer):
     - Default: `False`
     """
 
-    cap_rounded = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    cap_rounded = t.Bool(None, allow_none=True).tag(sync=True)
     """
     Type of caps. If `True`, draw round caps. Otherwise draw square caps.
 
@@ -1599,7 +1595,7 @@ class PathLayer(BaseArrowLayer):
     - Default: `False`
     """
 
-    miter_limit = traitlets.Int(None, allow_none=True).tag(sync=True)
+    miter_limit = t.Int(None, allow_none=True).tag(sync=True)
     """
     The maximum extent of a joint in ratio to the stroke width.
     Only works if `jointRounded` is `False`.
@@ -1608,7 +1604,7 @@ class PathLayer(BaseArrowLayer):
     - Default: `4`
     """
 
-    billboard = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    billboard = t.Bool(None, allow_none=True).tag(sync=True)
     """
     If `True`, extrude the path in screen space (width always faces the camera).
     If `False`, the width always faces up.
@@ -1700,7 +1696,7 @@ class PointCloudLayer(BaseArrowLayer):
     ) -> Self:
         return super().from_duckdb(sql=sql, con=con, crs=crs, **kwargs)
 
-    _layer_type = traitlets.Unicode("point-cloud").tag(sync=True)
+    _layer_type = t.Unicode("point-cloud").tag(sync=True)
 
     table = ArrowTableTrait(
         allowed_geometry_types={EXTENSION_NAME.POINT}, allowed_dimensions={3}
@@ -1715,7 +1711,7 @@ class PointCloudLayer(BaseArrowLayer):
     [`from_geopandas`][lonboard.PointCloudLayer.from_geopandas] instead.
     """
 
-    size_units = traitlets.Unicode(None, allow_none=True).tag(sync=True)
+    size_units = t.Unicode(None, allow_none=True).tag(sync=True)
     """
     The units of the line width, one of `'meters'`, `'common'`, and `'pixels'`. See
     [unit
@@ -1725,7 +1721,7 @@ class PointCloudLayer(BaseArrowLayer):
     - Default: `'pixels'`
     """
 
-    point_size = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
+    point_size = t.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     Global radius of all points, in units specified by `size_units`.
 
@@ -1833,7 +1829,7 @@ class SolidPolygonLayer(BaseArrowLayer):
     ) -> Self:
         return super().from_duckdb(sql=sql, con=con, crs=crs, **kwargs)
 
-    _layer_type = traitlets.Unicode("solid-polygon").tag(sync=True)
+    _layer_type = t.Unicode("solid-polygon").tag(sync=True)
 
     table = ArrowTableTrait(
         allowed_geometry_types={EXTENSION_NAME.POLYGON, EXTENSION_NAME.MULTIPOLYGON}
@@ -1848,7 +1844,7 @@ class SolidPolygonLayer(BaseArrowLayer):
     [`from_geopandas`][lonboard.SolidPolygonLayer.from_geopandas] instead.
     """
 
-    filled = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    filled = t.Bool(None, allow_none=True).tag(sync=True)
     """
     Whether to fill the polygons (based on the color provided by the
     `get_fill_color` accessor).
@@ -1857,7 +1853,7 @@ class SolidPolygonLayer(BaseArrowLayer):
     - Default: `True`
     """
 
-    extruded = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    extruded = t.Bool(None, allow_none=True).tag(sync=True)
     """
     Whether to extrude the polygons (based on the elevations provided by the
     `get_elevation` accessor'). If set to `False`, all polygons will be flat, this
@@ -1868,7 +1864,7 @@ class SolidPolygonLayer(BaseArrowLayer):
     - Default: `False`
     """
 
-    wireframe = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    wireframe = t.Bool(None, allow_none=True).tag(sync=True)
     """
     Whether to generate a line wireframe of the polygon. The outline will have
     "horizontal" lines closing the top and bottom polygons and a vertical line
@@ -1884,7 +1880,7 @@ class SolidPolygonLayer(BaseArrowLayer):
       with the same data if you want a combined rendering effect.
     """
 
-    elevation_scale = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
+    elevation_scale = t.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     Elevation multiplier. The final elevation is calculated by `elevation_scale *
     get_elevation(d)`. `elevation_scale` is a handy property to scale all elevation
@@ -2012,7 +2008,7 @@ class HeatmapLayer(BaseArrowLayer):
     ) -> Self:
         return super().from_duckdb(sql=sql, con=con, crs=crs, **kwargs)
 
-    _layer_type = traitlets.Unicode("heatmap").tag(sync=True)
+    _layer_type = t.Unicode("heatmap").tag(sync=True)
 
     table = ArrowTableTrait(allowed_geometry_types={EXTENSION_NAME.POINT})
     """A GeoArrow table with a Point column.
@@ -2025,7 +2021,7 @@ class HeatmapLayer(BaseArrowLayer):
     [`from_geopandas`][lonboard.HeatmapLayer.from_geopandas] instead.
     """
 
-    radius_pixels = traitlets.Float(None, allow_none=True).tag(sync=True)
+    radius_pixels = t.Float(None, allow_none=True).tag(sync=True)
     """Radius of the circle in pixels, to which the weight of an object is distributed.
 
     - Type: `float`, optional
@@ -2039,7 +2035,7 @@ class HeatmapLayer(BaseArrowLayer):
     # - Default: `6-class YlOrRd` - [colorbrewer](http://colorbrewer2.org/#type=sequential&scheme=YlOrRd&n=6)
     # """
 
-    intensity = traitlets.Float(None, allow_none=True).tag(sync=True)
+    intensity = t.Float(None, allow_none=True).tag(sync=True)
     """
     Value that is multiplied with the total weight at a pixel to obtain the final
     weight.
@@ -2048,7 +2044,7 @@ class HeatmapLayer(BaseArrowLayer):
     - Default: `1`
     """
 
-    threshold = traitlets.Float(None, allow_none=True, min=0, max=1).tag(sync=True)
+    threshold = t.Float(None, allow_none=True, min=0, max=1).tag(sync=True)
     """Ratio of the fading weight to the max weight, between `0` and `1`.
 
     For example, `0.1` affects all pixels with weight under 10% of the max.
@@ -2060,7 +2056,7 @@ class HeatmapLayer(BaseArrowLayer):
     """
 
     color_domain = VariableLengthTuple(
-        traitlets.Float(), default_value=None, allow_none=True, minlen=2, maxlen=2
+        t.Float(), default_value=None, allow_none=True, minlen=2, maxlen=2
     ).tag(sync=True)
     # """
     # Controls how weight values are mapped to the `color_range`, as an array of two
@@ -2070,7 +2066,7 @@ class HeatmapLayer(BaseArrowLayer):
     # - Default: `None`
     # """
 
-    aggregation = traitlets.Unicode(None, allow_none=True).tag(sync=True)
+    aggregation = t.Unicode(None, allow_none=True).tag(sync=True)
     """Defines the type of aggregation operation
 
     Valid values are 'SUM', 'MEAN'.
@@ -2079,14 +2075,14 @@ class HeatmapLayer(BaseArrowLayer):
     - Default: `"SUM"`
     """
 
-    weights_texture_size = traitlets.Int(None, allow_none=True).tag(sync=True)
+    weights_texture_size = t.Int(None, allow_none=True).tag(sync=True)
     """Specifies the size of weight texture.
 
     - Type: `int`, optional
     - Default: `2048`
     """
 
-    debounce_timeout = traitlets.Int(None, allow_none=True).tag(sync=True)
+    debounce_timeout = t.Int(None, allow_none=True).tag(sync=True)
     """
     Interval in milliseconds during which changes to the viewport don't trigger
     aggregation.

--- a/lonboard/_map.py
+++ b/lonboard/_map.py
@@ -7,6 +7,7 @@ from typing import IO, TYPE_CHECKING, Optional, Sequence, TextIO, Union, overloa
 
 import ipywidgets
 import traitlets
+import traitlets as t
 from ipywidgets.embed import embed_minimal_html
 
 from lonboard._base import BaseAnyWidget
@@ -128,21 +129,19 @@ class Map(BaseAnyWidget):
 
     """
 
-    _height = traitlets.Int(default_value=DEFAULT_HEIGHT, allow_none=True).tag(
-        sync=True
-    )
+    _height = t.Int(default_value=DEFAULT_HEIGHT, allow_none=True).tag(sync=True)
     """Height of the map in pixels.
 
     This API is not yet stabilized and may change in the future.
     """
 
-    layers = VariableLengthTuple(traitlets.Instance(BaseLayer)).tag(
+    layers = VariableLengthTuple(t.Instance(BaseLayer)).tag(
         sync=True, **ipywidgets.widget_serialization
     )
     """One or more `Layer` objects to display on this map.
     """
 
-    show_tooltip = traitlets.Bool(True).tag(sync=True)
+    show_tooltip = t.Bool(True).tag(sync=True)
     """
     Whether to render a tooltip on hover on the map.
 
@@ -150,7 +149,7 @@ class Map(BaseAnyWidget):
     - Default: `True`
     """
 
-    picking_radius = traitlets.Int(5).tag(sync=True)
+    picking_radius = t.Int(5).tag(sync=True)
     """
     Extra pixels around the pointer to include while picking (such as for a tooltip).
 
@@ -172,10 +171,10 @@ class Map(BaseAnyWidget):
       [`lonboard.basemap.CartoBasemap.PositronNoLabels`][lonboard.basemap.CartoBasemap.PositronNoLabels]
     """
 
-    custom_attribution = traitlets.Union(
+    custom_attribution = t.Union(
         [
-            traitlets.Unicode(allow_none=True),
-            VariableLengthTuple(traitlets.Unicode(allow_none=False)),
+            t.Unicode(allow_none=True),
+            VariableLengthTuple(t.Unicode(allow_none=False)),
         ]
     ).tag(sync=True)
     """
@@ -215,9 +214,7 @@ class Map(BaseAnyWidget):
     # want, and `Union[float, bool]` would coerce `True` to `1`, which we also don't
     # want.
     # In the future we could create a custom trait for this if asked for.
-    use_device_pixels = traitlets.Any(allow_none=True, default_value=None).tag(
-        sync=True
-    )
+    use_device_pixels = t.Any(allow_none=True, default_value=None).tag(sync=True)
     """Controls the resolution of the drawing buffer used for rendering.
 
     Setting this to `false` or a number <= 1 will improve performance on high resolution
@@ -243,7 +240,7 @@ class Map(BaseAnyWidget):
     - Default: `true`
     """
 
-    parameters = traitlets.Any(allow_none=True, default_value=None).tag(sync=True)
+    parameters = t.Any(allow_none=True, default_value=None).tag(sync=True)
     """GPU parameters to pass to deck.gl.
 
     **This is an advanced API. The vast majority of users should not need to touch this

--- a/lonboard/experimental/_layer.py
+++ b/lonboard/experimental/_layer.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-import traitlets
+import traitlets as t
 
 from lonboard._constants import EXTENSION_NAME
 from lonboard._layer import BaseArrowLayer
@@ -21,7 +21,7 @@ from lonboard.traits import (
 class ArcLayer(BaseArrowLayer):
     """Render raised arcs joining pairs of source and target coordinates."""
 
-    _layer_type = traitlets.Unicode("arc").tag(sync=True)
+    _layer_type = t.Unicode("arc").tag(sync=True)
 
     table = ArrowTableTrait()
     """A GeoArrow table.
@@ -34,21 +34,21 @@ class ArcLayer(BaseArrowLayer):
     [`from_geopandas`][lonboard.ScatterplotLayer.from_geopandas] instead.
     """
 
-    great_circle = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    great_circle = t.Bool(None, allow_none=True).tag(sync=True)
     """If `True`, create the arc along the shortest path on the earth surface.
 
     - Type: `bool`, optional
     - Default: `False`
     """
 
-    num_segments = traitlets.Int(None, allow_none=True).tag(sync=True)
+    num_segments = t.Int(None, allow_none=True).tag(sync=True)
     """The number of segments used to draw each arc.
 
     - Type: `int`, optional
     - Default: `50`
     """
 
-    width_units = traitlets.Unicode(None, allow_none=True).tag(sync=True)
+    width_units = t.Unicode(None, allow_none=True).tag(sync=True)
     """
     The units of the line width, one of `'meters'`, `'common'`, and `'pixels'`. See
     [unit
@@ -58,7 +58,7 @@ class ArcLayer(BaseArrowLayer):
     - Default: `'pixels'`
     """
 
-    width_scale = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
+    width_scale = t.Float(None, allow_none=True, min=0).tag(sync=True)
     """
     The scaling multiplier for the width of each line.
 
@@ -66,14 +66,14 @@ class ArcLayer(BaseArrowLayer):
     - Default: `1`
     """
 
-    width_min_pixels = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
+    width_min_pixels = t.Float(None, allow_none=True, min=0).tag(sync=True)
     """The minimum line width in pixels.
 
     - Type: `float`, optional
     - Default: `0`
     """
 
-    width_max_pixels = traitlets.Float(None, allow_none=True, min=0).tag(sync=True)
+    width_max_pixels = t.Float(None, allow_none=True, min=0).tag(sync=True)
     """The maximum line width in pixels.
 
     - Type: `float`, optional
@@ -126,7 +126,7 @@ class ArcLayer(BaseArrowLayer):
 class TextLayer(BaseArrowLayer):
     """Render text labels at given coordinates."""
 
-    _layer_type = traitlets.Unicode("text").tag(sync=True)
+    _layer_type = t.Unicode("text").tag(sync=True)
 
     table = ArrowTableTrait(allowed_geometry_types={EXTENSION_NAME.POINT})
     """A GeoArrow table with a Point or MultiPoint column.
@@ -139,21 +139,21 @@ class TextLayer(BaseArrowLayer):
     [`from_geopandas`][lonboard.ScatterplotLayer.from_geopandas] instead.
     """
 
-    billboard = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    billboard = t.Bool(None, allow_none=True).tag(sync=True)
     """If `true`, the text always faces camera. Otherwise the text faces up (z).
 
     - Type: `bool`
     - Default: `True`
     """
 
-    size_scale = traitlets.Any(None, allow_none=True).tag(sync=True)
+    size_scale = t.Any(None, allow_none=True).tag(sync=True)
     """Text size multiplier.
 
     - Type: `float`.
     - Default: `1`
     """
 
-    size_units = traitlets.Any(None, allow_none=True).tag(sync=True)
+    size_units = t.Any(None, allow_none=True).tag(sync=True)
     """The units of the size, one of `'meters'`, `'common'`, and `'pixels'`.
     default 'pixels'. See [unit
     system](https://deck.gl/docs/developer-guide/coordinate-systems#supported-units).
@@ -162,7 +162,7 @@ class TextLayer(BaseArrowLayer):
     - Default: `'pixels'`
     """
 
-    size_min_pixels = traitlets.Any(None, allow_none=True).tag(sync=True)
+    size_min_pixels = t.Any(None, allow_none=True).tag(sync=True)
     """
     The minimum size in pixels. When using non-pixel `sizeUnits`, this prop can be used
     to prevent the icon from getting too small when zoomed out.
@@ -171,7 +171,7 @@ class TextLayer(BaseArrowLayer):
     - Default: `0`
     """
 
-    size_max_pixels = traitlets.Any(None, allow_none=True).tag(sync=True)
+    size_max_pixels = t.Any(None, allow_none=True).tag(sync=True)
     """
     The maximum size in pixels. When using non-pixel `sizeUnits`, this prop can be used
     to prevent the icon from getting too big when zoomed in.
@@ -180,7 +180,7 @@ class TextLayer(BaseArrowLayer):
     - Default: `None`
     """
 
-    # background = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    # background = t.Bool(None, allow_none=True).tag(sync=True)
     # """Whether to render background for the text blocks.
 
     # - Type: `bool`
@@ -205,7 +205,7 @@ class TextLayer(BaseArrowLayer):
     default 0
     """
 
-    background_padding = traitlets.Any(None, allow_none=True).tag(sync=True)
+    background_padding = t.Any(None, allow_none=True).tag(sync=True)
     """The padding of the background.
 
     - If an array of 2 is supplied, it is interpreted as `[padding_x, padding_y]` in
@@ -216,7 +216,7 @@ class TextLayer(BaseArrowLayer):
     default [0, 0, 0, 0]
     """
 
-    character_set = traitlets.Any(None, allow_none=True).tag(sync=True)
+    character_set = t.Any(None, allow_none=True).tag(sync=True)
     """
     Specifies a list of characters to include in the font. If set to 'auto', will be
     automatically generated from the data set.
@@ -224,25 +224,25 @@ class TextLayer(BaseArrowLayer):
     default (ASCII characters 32-128)
     """
 
-    font_family = traitlets.Any(None, allow_none=True).tag(sync=True)
+    font_family = t.Any(None, allow_none=True).tag(sync=True)
     """CSS font family
 
     default 'Monaco, monospace'
     """
 
-    font_weight = traitlets.Any(None, allow_none=True).tag(sync=True)
+    font_weight = t.Any(None, allow_none=True).tag(sync=True)
     """CSS font weight
 
     default 'normal'
     """
 
-    line_height = traitlets.Any(None, allow_none=True).tag(sync=True)
+    line_height = t.Any(None, allow_none=True).tag(sync=True)
     """
     A unitless number that will be multiplied with the current text size to set the line
     height.
     """
 
-    outline_width = traitlets.Any(None, allow_none=True).tag(sync=True)
+    outline_width = t.Any(None, allow_none=True).tag(sync=True)
     """
     Width of outline around the text, relative to the text size. Only effective if
     `fontSettings.sdf` is `true`.
@@ -250,7 +250,7 @@ class TextLayer(BaseArrowLayer):
     default 0
     """
 
-    outline_color = traitlets.Any(None, allow_none=True).tag(sync=True)
+    outline_color = t.Any(None, allow_none=True).tag(sync=True)
     """
     Color of outline around the text, in `[r, g, b, [a]]`. Each channel is a number
     between 0-255 and `a` is 255 if not supplied.
@@ -258,13 +258,13 @@ class TextLayer(BaseArrowLayer):
     default [0, 0, 0, 255]
     """
 
-    font_settings = traitlets.Any(None, allow_none=True).tag(sync=True)
+    font_settings = t.Any(None, allow_none=True).tag(sync=True)
     """
     Advance options for fine tuning the appearance and performance of the generated
     shared `fontAtlas`.
     """
 
-    word_break = traitlets.Any(None, allow_none=True).tag(sync=True)
+    word_break = t.Any(None, allow_none=True).tag(sync=True)
     """
     Available options are `break-all` and `break-word`. A valid `maxWidth` has to be
     provided to use `wordBreak`.
@@ -272,7 +272,7 @@ class TextLayer(BaseArrowLayer):
     default 'break-word'
     """
 
-    max_width = traitlets.Any(None, allow_none=True).tag(sync=True)
+    max_width = t.Any(None, allow_none=True).tag(sync=True)
     """
     A unitless number that will be multiplied with the current text size to set the
     width limit of a string.
@@ -286,7 +286,7 @@ class TextLayer(BaseArrowLayer):
     get_text = TextAccessor(None, allow_none=True)
     """Label text accessor"""
 
-    # get_position = traitlets.Any(None, allow_none=True).tag(sync=True)
+    # get_position = t.Any(None, allow_none=True).tag(sync=True)
     # """Anchor position accessor"""
 
     #  ?: Accessor<DataT, Position>;
@@ -309,21 +309,21 @@ class TextLayer(BaseArrowLayer):
     default 0
     """
 
-    get_text_anchor = traitlets.Any(None, allow_none=True).tag(sync=True)
+    get_text_anchor = t.Any(None, allow_none=True).tag(sync=True)
     """Horizontal alignment accessor
 
     default 'middle'
     """
     #  ?: Accessor<DataT, 'start' | 'middle' | 'end'>;
 
-    get_alignment_baseline = traitlets.Any(None, allow_none=True).tag(sync=True)
+    get_alignment_baseline = t.Any(None, allow_none=True).tag(sync=True)
     """Vertical alignment accessor
 
     default 'center'
     """
     #  ?: Accessor<DataT, 'top' | 'center' | 'bottom'>;
 
-    get_pixel_offset = traitlets.Any(None, allow_none=True).tag(sync=True)
+    get_pixel_offset = t.Any(None, allow_none=True).tag(sync=True)
     """Label offset from the anchor position, [x, y] in pixels
 
     default [0, 0]

--- a/lonboard/layer_extension.py
+++ b/lonboard/layer_extension.py
@@ -1,4 +1,4 @@
-import traitlets
+import traitlets as t
 
 from lonboard._base import BaseExtension
 from lonboard.traits import (
@@ -76,12 +76,12 @@ class BrushingExtension(BaseExtension):
     - Default: `None`.
     """
 
-    _extension_type = traitlets.Unicode("brushing").tag(sync=True)
+    _extension_type = t.Unicode("brushing").tag(sync=True)
 
     _layer_traits = {
-        "brushing_enabled": traitlets.Bool(True).tag(sync=True),
-        "brushing_target": traitlets.Unicode(None, allow_none=True).tag(sync=True),
-        "brushing_radius": traitlets.Float(None, allow_none=True, min=0).tag(sync=True),
+        "brushing_enabled": t.Bool(True).tag(sync=True),
+        "brushing_target": t.Unicode(None, allow_none=True).tag(sync=True),
+        "brushing_radius": t.Float(None, allow_none=True, min=0).tag(sync=True),
         "get_brushing_target": PointAccessor(None, allow_none=True),
     }
 
@@ -122,11 +122,11 @@ class CollisionFilterExtension(BaseExtension):
 
     """
 
-    _extension_type = traitlets.Unicode("collision-filter").tag(sync=True)
+    _extension_type = t.Unicode("collision-filter").tag(sync=True)
 
     _layer_traits = {
-        "collision_enabled": traitlets.Bool(True).tag(sync=True),
-        "collision_group": traitlets.Unicode(None, allow_none=True).tag(sync=True),
+        "collision_enabled": t.Bool(True).tag(sync=True),
+        "collision_group": t.Unicode(None, allow_none=True).tag(sync=True),
         "get_collision_priority": FloatAccessor(None, allow_none=True),
     }
 
@@ -314,14 +314,14 @@ class DataFilterExtension(BaseExtension):
           the object at the same row index.
     """
 
-    _extension_type = traitlets.Unicode("data-filter").tag(sync=True)
+    _extension_type = t.Unicode("data-filter").tag(sync=True)
 
     _layer_traits = {
-        "filter_categories": traitlets.Union(
+        "filter_categories": t.Union(
             [
-                VariableLengthTuple(traitlets.Any()),
+                VariableLengthTuple(t.Any()),
                 VariableLengthTuple(
-                    VariableLengthTuple(traitlets.Any()),
+                    VariableLengthTuple(t.Any()),
                     minlen=2,
                     maxlen=4,
                 ),
@@ -329,12 +329,12 @@ class DataFilterExtension(BaseExtension):
             default_value=None,
             allow_none=True,
         ).tag(sync=True),
-        "filter_enabled": traitlets.Bool(True).tag(sync=True),
-        "filter_range": traitlets.Union(
+        "filter_enabled": t.Bool(True).tag(sync=True),
+        "filter_range": t.Union(
             [
-                VariableLengthTuple(traitlets.Float(), minlen=2, maxlen=2),
+                VariableLengthTuple(t.Float(), minlen=2, maxlen=2),
                 VariableLengthTuple(
-                    VariableLengthTuple(traitlets.Float(), minlen=2, maxlen=2),
+                    VariableLengthTuple(t.Float(), minlen=2, maxlen=2),
                     minlen=2,
                     maxlen=4,
                 ),
@@ -342,16 +342,16 @@ class DataFilterExtension(BaseExtension):
             default_value=None,
             allow_none=True,
         ).tag(sync=True),
-        "filter_soft_range": traitlets.Tuple(
-            traitlets.Float(), traitlets.Float(), default_value=None, allow_none=True
+        "filter_soft_range": t.Tuple(
+            t.Float(), t.Float(), default_value=None, allow_none=True
         ).tag(sync=True),
-        "filter_transform_size": traitlets.Bool(True).tag(sync=True),
-        "filter_transform_color": traitlets.Bool(True).tag(sync=True),
+        "filter_transform_size": t.Bool(True).tag(sync=True),
+        "filter_transform_color": t.Bool(True).tag(sync=True),
         "get_filter_value": FilterValueAccessor(default_value=None, allow_none=True),
         "get_filter_category": FilterValueAccessor(default_value=None, allow_none=True),
     }
 
-    filter_size = traitlets.Int(None, min=1, max=4, allow_none=True).tag(sync=True)
+    filter_size = t.Int(None, min=1, max=4, allow_none=True).tag(sync=True)
     """The size of the filter (number of columns to filter by).
 
     The data filter can show/hide data based on 1-4 numeric properties of each object.
@@ -360,7 +360,7 @@ class DataFilterExtension(BaseExtension):
     - Default 1.
     """
 
-    category_size = traitlets.Int(None, min=1, max=4, allow_none=True).tag(sync=True)
+    category_size = t.Int(None, min=1, max=4, allow_none=True).tag(sync=True)
     """The size of the category filter (number of columns to filter by).
 
     The category filter can show/hide data based on 1-4 properties of each object.
@@ -456,23 +456,23 @@ class PathStyleExtension(BaseExtension):
     segments, this mode yields the best result.
     """
 
-    _extension_type = traitlets.Unicode("path-style").tag(sync=True)
+    _extension_type = t.Unicode("path-style").tag(sync=True)
 
     _layer_traits = {
         "get_dash_array": DashArrayAccessor(None, allow_none=True),
-        "dash_justified": traitlets.Bool(None, allow_none=True).tag(sync=True),
+        "dash_justified": t.Bool(None, allow_none=True).tag(sync=True),
         "get_offset": FloatAccessor(None, allow_none=True),
-        "dash_gap_pickable": traitlets.Bool(None, allow_none=True).tag(sync=True),
+        "dash_gap_pickable": t.Bool(None, allow_none=True).tag(sync=True),
     }
 
-    dash = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    dash = t.Bool(None, allow_none=True).tag(sync=True)
     """Add capability to render dashed lines.
 
     - Type: `boolean`, optional
     - Default False.
     """
 
-    high_precision_dash = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    high_precision_dash = t.Bool(None, allow_none=True).tag(sync=True)
     """Improve dash rendering quality in certain circumstances.
 
     Note that this option introduces additional performance overhead. See "Remarks".
@@ -481,7 +481,7 @@ class PathStyleExtension(BaseExtension):
     - Default `False`.
     """
 
-    offset = traitlets.Bool(None, allow_none=True).tag(sync=True)
+    offset = t.Bool(None, allow_none=True).tag(sync=True)
     """Add capability to offset lines.
 
     - Type: `boolean`, optional


### PR DESCRIPTION
Just a stylistic choice because we're using `traitlets.*` often in our code, and I don't want to bring all of the traitlets objects into global scope.