### PR TITLE
Move `selected_bounds` from `Layer` to `Map`

### DIFF
--- a/lonboard/_layer.py
+++ b/lonboard/_layer.py
@@ -250,17 +250,6 @@ class BaseLayer(BaseWidget):
     - Default: `[0, 0, 128, 128]`
     """
 
-    selected_bounds = t.Tuple(
-        t.Float(), t.Float(), t.Float(), t.Float(), allow_none=True, default_value=None
-    ).tag(sync=True)
-    """
-    Bounds selected by the user, represented as a tuple of floats ordered as
-
-    ```
-    (minx, miny, maxx, maxy)
-    ```
-    """
-
     selected_index = t.Int(None, allow_none=True).tag(sync=True)
     """
     The positional index of the most-recently clicked on row of data.

--- a/lonboard/_map.py
+++ b/lonboard/_map.py
@@ -308,6 +308,17 @@ class Map(BaseAnyWidget):
       global `parameters` when that layer is rendered.
     """
 
+    selected_bounds = t.Tuple(
+        t.Float(), t.Float(), t.Float(), t.Float(), allow_none=True, default_value=None
+    ).tag(sync=True)
+    """
+    Bounds selected by the user, represented as a tuple of floats ordered as
+
+    ```
+    (minx, miny, maxx, maxy)
+    ```
+    """
+
     def add_layer(
         self,
         layers: BaseLayer | Sequence[BaseLayer] | Map,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -157,10 +157,14 @@ function App() {
         setSubModelState(newSubModelState);
 
         if (!isDrawingBBoxSelection) {
-          childModels.forEach((layer) => {
-            layer.set("selected_bounds", bboxSelectBounds);
-            layer.save_changes();
-          });
+          // Note: selected_bounds is a property of the **Map**. In the future,
+          // when we use deck.gl to perform picking, we'll have
+          // `selected_indices` as a property of each individual layer.
+          model.set("selected_bounds", bboxSelectBounds);
+          // childModels.forEach((layer) => {
+          //   layer.set("selected_bounds", bboxSelectBounds);
+          //   layer.save_changes();
+          // });
         }
       } catch (error) {
         console.error("Error loading child models or setting bounds:", error);


### PR DESCRIPTION
`selected_bounds` should be a property of the **Map**. In the future, when we use deck.gl to perform picking, we'll have `selected_indices` as a property of each _individual layer_. This is necessary because the data is a property of each layer, while 

Or alternatively if we perform data filtering on the Python side, then in the future we could also add `selected_bounds` to each layer (though probably as a private attribute)
