### PR TITLE
Fix import when pandas/pyarrow not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.10.1] - 2024-10-08
+
+### Fixes :bug:
+
+- Fix import when pandas not installed.
+
 ## [0.10.0] - 2024-10-07
 
 ### New! :sparkles:
@@ -29,7 +35,7 @@
 - Fix reading from DuckDB with only geometry column by @kylebarron in https://github.com/developmentseed/lonboard/pull/625
 - Fix attribution by @vgeorge in https://github.com/developmentseed/lonboard/pull/561
 
-## New Contributors
+### New Contributors
 
 - @MarcSkovMadsen made their first contribution in https://github.com/developmentseed/lonboard/pull/539
 - @ATL2001 made their first contribution in https://github.com/developmentseed/lonboard/pull/655

--- a/lonboard/types/layer.py
+++ b/lonboard/types/layer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 from typing import (
+    TYPE_CHECKING,
     List,
     Literal,
     Sequence,
@@ -10,8 +11,6 @@ from typing import (
 )
 
 import numpy as np
-import pandas as pd
-import pyarrow
 from arro3.core.types import ArrowArrayExportable, ArrowStreamExportable
 from numpy.typing import NDArray
 
@@ -21,6 +20,10 @@ if sys.version_info >= (3, 12):
     from typing import TypedDict
 else:
     from typing_extensions import TypedDict
+
+if TYPE_CHECKING:
+    import pandas as pd
+    import pyarrow
 
 
 IntFloat = Union[int, float]
@@ -32,8 +35,8 @@ ColorAccessorInput = Union[
     Tuple[int, ...],
     str,
     NDArray[np.uint8],
-    pyarrow.FixedSizeListArray,
-    pyarrow.ChunkedArray,
+    "pyarrow.FixedSizeListArray",
+    "pyarrow.ChunkedArray",
     ArrowArrayExportable,
     ArrowStreamExportable,
 ]
@@ -41,9 +44,9 @@ FloatAccessorInput = Union[
     int,
     float,
     NDArray[np.number],
-    pd.Series,
-    pyarrow.FloatingPointArray,
-    pyarrow.ChunkedArray,
+    "pd.Series",
+    "pyarrow.FloatingPointArray",
+    "pyarrow.ChunkedArray",
     ArrowArrayExportable,
     ArrowStreamExportable,
 ]
@@ -52,18 +55,18 @@ NormalAccessorInput = Union[
     Tuple[int, int, int],
     Tuple[int, ...],
     NDArray[np.floating],
-    pyarrow.FixedSizeListArray,
-    pyarrow.ChunkedArray,
+    "pyarrow.FixedSizeListArray",
+    "pyarrow.ChunkedArray",
     ArrowArrayExportable,
     ArrowStreamExportable,
 ]
 TextAccessorInput = Union[
     str,
     NDArray[np.str_],
-    pd.Series,
-    pyarrow.StringArray,
-    pyarrow.LargeStringArray,
-    pyarrow.ChunkedArray,
+    "pd.Series",
+    "pyarrow.StringArray",
+    "pyarrow.LargeStringArray",
+    "pyarrow.ChunkedArray",
     ArrowArrayExportable,
     ArrowStreamExportable,
 ]


### PR DESCRIPTION
## Available PR templates

<!--
  Github doesn't allow PR template selection the same way that it is possible with issues.
  Preview this and select the appropriate template
-->

- [Default](?expand=1&template=default.md)
- [Version Release](?expand=1&template=version_release.md)
- _Alternatively delete and start empty_
