### PR TITLE
Pass state in `to_html`

### DIFF
--- a/lonboard/_map.py
+++ b/lonboard/_map.py
@@ -545,6 +545,9 @@ class Map(BaseAnyWidget):
                 title=title or "Lonboard export",
                 template=_HTML_TEMPLATE,
                 drop_defaults=False,
+                # Necessary to pass the state of _this_ specific map. Otherwise, the
+                # state of all known widgets will be included, ballooning the file size.
+                state=self.get_state(),
             )
 
         if filename is None:


### PR DESCRIPTION
Closes https://github.com/developmentseed/lonboard/issues/725#issuecomment-2572885038

Avoids including the data from _all_ previous widgets.