### PR TITLE
Sanitize geomcolname

### DIFF
--- a/lonboard/_geoarrow/_duckdb.py
+++ b/lonboard/_geoarrow/_duckdb.py
@@ -115,7 +115,7 @@ def _from_geometry(
     # A poor-man's string interpolation check
     # We can't pass in SQL-templated strings for the column name
     re_match = r"[a-zA-Z][a-zA-Z0-9_]*"
-    assert re.match(
+    assert re.fullmatch(
         re_match,
         geom_col_name,
     ), f"Expected geometry column name to match regex: {re_match}"

--- a/tests/test_duckdb.py
+++ b/tests/test_duckdb.py
@@ -258,7 +258,7 @@ def test_sanitize_column_name():
     rel = con.sql(sql)
 
     with pytest.raises(
-        duckdb.duckdb.ParserException,
-        match="Parser Error: syntax error at or near",
+        AssertionError,
+        match="Expected geometry column name to match regex:",
     ):
         viz(rel, con=con)


### PR DESCRIPTION
## What I am changing

Fix sanity check of `geom_col_name` to actually check the whole string.

## How I did it

`re.match(re_match)` was matching any string containing _any_ `[a-zA-Z]` character, regardless of the rest.
The solution is `re.fullmatch()`. Another way would have been to append `r"^...$"` to the beginning and end of `re_match`.

## How you can test it
Wrote test `test_sanitize_column_name()`.

## Related Issues
Closes #768

In general, the issue of [hardcoded-sql-expression](https://github.com/developmentseed/lonboard/blob/98d68f750ece7d09e209edba354e124ceb3416d5/lonboard/_geoarrow/_duckdb.py#L1) is still out there.
