### PR TITLE
follow stage rename in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ default_language_version:
   python: python3
 
 # Optionally both commit and push
-default_stages: [commit]
+default_stages: [pre-commit]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
the possible value for `default_stages` is now called "pre-commit", according to https://pre-commit.com/#pre-commit-configyaml---top-level and the warning put out by `pre-commit==4.1.0` when using legacy "commit":

```bash
$ pre-commit run
[WARNING] top-level `default_stages` uses deprecated stage names (commit) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
```