### PR TITLE
include table name in con.table() example

### DIFF
--- a/lonboard/_viz.py
+++ b/lonboard/_viz.py
@@ -146,7 +146,7 @@ def viz(
 
             con = duckdb.connect()
             con.execute("CREATE TABLE spatial_table AS ...;")
-            viz(con.table(), con=con)
+            viz(con.table("spatial_table"), con=con)
             ```
 
         !!! warning


### PR DESCRIPTION
as the previous code snippet line already includes an example table name ("spatial_table"), I suggest to include this in the `viz()` call below for continuity, clarity (even though I understand that these examples are not complete running code, again for clarity).

(or at least it should be `con.table(...)` to follow the pattern of ellipses in the previous line, to make it clear it is not a function call without parameters)