### PR TITLE
docs: Add duckdb intersphinx mapping

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -176,10 +176,11 @@ plugins:
             extensions:
               - griffe_inherited_docstrings
 
-          import:
+          inventories:
             - https://arrow.apache.org/docs/objects.inv
             - https://contextily.readthedocs.io/en/stable/objects.inv
             - https://docs.python.org/3/objects.inv
+            - https://duckdb.org/docs/stable/clients/python/reference/objects.inv
             - https://fiona.readthedocs.io/en/stable/objects.inv
             - https://geoarrow.github.io/geoarrow-rs/python/latest/objects.inv
             - https://geopandas.org/en/stable/objects.inv


### PR DESCRIPTION
Linking now works:
<img width="716" alt="image" src="https://github.com/user-attachments/assets/c372376a-9ec0-465a-81d8-19112d98b52a" />


Closes https://github.com/developmentseed/lonboard/issues/774