### PR TITLE
fix: move duckdb imports to inside function

### DIFF
--- a/lonboard/_geoarrow/_duckdb.py
+++ b/lonboard/_geoarrow/_duckdb.py
@@ -14,7 +14,6 @@ from arro3.core import (
     list_array,
     struct_field,
 )
-from duckdb import ColumnExpression, FunctionExpression
 
 from lonboard._constants import EXTENSION_NAME
 
@@ -101,6 +100,8 @@ def _from_geometry(
     geom_col_idx: int,
     crs: str | pyproj.CRS | None = None,
 ) -> Table:
+    from duckdb import ColumnExpression, FunctionExpression
+
     other_col_names = [name for i, name in enumerate(rel.columns) if i != geom_col_idx]
     if other_col_names:
         non_geo_table = Table.from_arrow(rel.select(*other_col_names).arrow())


### PR DESCRIPTION
to avoid duckdb becoming a hard dependency

## What I am changing / How I did it
move import to inside function

## How you can test it
might trigger a ruff rule around imports not at top of file

## Related Issues
closes #810 

(or alternatively, duckdb should explicitly become a hard dependency)