### PR TITLE
chore: Use `>=` in typing-extensions version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "numpy>=1.14",
     # The same version pin as geopandas
     "pyproj>=3.3",
-    "typing-extensions~=4.6.0; python_version < '3.12'",
+    "typing-extensions>=4.6.0; python_version < '3.12'",
 ]
 keywords = [
     "GIS",

--- a/uv.lock
+++ b/uv.lock
@@ -2076,7 +2076,7 @@ wheels = [
 
 [[package]]
 name = "lonboard"
-version = "0.10.3"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },
@@ -2162,7 +2162,7 @@ requires-dist = [
     { name = "shapely", marker = "extra == 'cli'", specifier = ">=2" },
     { name = "shapely", marker = "extra == 'geopandas'", specifier = ">=2" },
     { name = "traitlets", specifier = ">=5.7.1" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'", specifier = "~=4.6.0" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'", specifier = ">=4.6.0" },
 ]
 provides-extras = ["cli", "geopandas", "movingpandas"]
 


### PR DESCRIPTION
Closes #812 