### PR TITLE
feat: Allow passing GeoArrow arrays and chunked arrays directly to layer constructors

### DIFF
--- a/lonboard/_geoarrow/ops/coord_layout.py
+++ b/lonboard/_geoarrow/ops/coord_layout.py
@@ -33,6 +33,11 @@ def make_geometry_interleaved(
     geom_field = table.schema.field(geom_col_idx)
     geom_column = table.column(geom_col_idx)
 
+    # The GeoArrow box extension type is only struct, not interleaved. It will be
+    # converted to an interleaved polygon separately, if needed.
+    if geom_field.metadata.get(b"ARROW:extension:name") == EXTENSION_NAME.BOX:
+        return table
+
     new_field, new_column = transpose_column(field=geom_field, column=geom_column)
     return table.set_column(geom_col_idx, new_field, new_column)
 

--- a/lonboard/_geoarrow/row_index.py
+++ b/lonboard/_geoarrow/row_index.py
@@ -1,0 +1,18 @@
+import numpy as np
+from arro3.core import Array, ChunkedArray, Table
+
+
+def add_positional_row_index(
+    table: Table,
+) -> Table:
+    num_rows = table.num_rows
+    if num_rows <= np.iinfo(np.uint8).max:
+        arange_col = Array(np.arange(num_rows, dtype=np.uint8))
+    elif num_rows <= np.iinfo(np.uint16).max:
+        arange_col = Array(np.arange(num_rows, dtype=np.uint16))
+    elif num_rows <= np.iinfo(np.uint32).max:
+        arange_col = Array(np.arange(num_rows, dtype=np.uint32))
+    else:
+        arange_col = Array(np.arange(num_rows, dtype=np.uint64))
+
+    return table.append_column("row_index", ChunkedArray([arange_col]))

--- a/lonboard/_viz.py
+++ b/lonboard/_viz.py
@@ -24,6 +24,7 @@ from lonboard._geoarrow.c_stream_import import import_arrow_c_stream
 from lonboard._geoarrow.extension_types import construct_geometry_array
 from lonboard._geoarrow.geopandas_interop import geopandas_to_geoarrow
 from lonboard._geoarrow.parse_wkb import parse_serialized_table
+from lonboard._geoarrow.row_index import add_positional_row_index
 from lonboard._layer import PathLayer, PolygonLayer, ScatterplotLayer
 from lonboard._map import Map
 from lonboard._utils import (
@@ -447,18 +448,7 @@ def _viz_geoarrow_chunked_array(
     field = ca.field.with_name("geometry")
     schema = Schema([field])
     table = Table.from_arrays([ca], schema=schema)
-
-    num_rows = len(ca)
-    if num_rows <= np.iinfo(np.uint8).max:
-        arange_col = Array(np.arange(num_rows, dtype=np.uint8))
-    elif num_rows <= np.iinfo(np.uint16).max:
-        arange_col = Array(np.arange(num_rows, dtype=np.uint16))
-    elif num_rows <= np.iinfo(np.uint32).max:
-        arange_col = Array(np.arange(num_rows, dtype=np.uint32))
-    else:
-        arange_col = Array(np.arange(num_rows, dtype=np.uint64))
-
-    table = table.append_column("row_index", ChunkedArray([arange_col]))
+    table = add_positional_row_index(table)
     return _viz_geoarrow_table(table, **kwargs)
 
 

--- a/lonboard/traits.py
+++ b/lonboard/traits.py
@@ -27,6 +27,8 @@ from arro3.core import (
 from traitlets import TraitError, Undefined
 from traitlets.utils.descriptions import class_of, describe
 
+from lonboard._constants import EXTENSION_NAME
+from lonboard._geoarrow.box_to_polygon import parse_box_encoded_table
 from lonboard._serialization import (
     ACCESSOR_SERIALIZATION,
     TABLE_SERIALIZATION,
@@ -42,7 +44,6 @@ if TYPE_CHECKING:
     from traitlets.traitlets import TraitType
     from traitlets.utils.sentinel import Sentinel
 
-    from lonboard._constants import EXTENSION_NAME
     from lonboard._layer import BaseArrowLayer
 
 DEFAULT_INITIAL_VIEW_STATE = {
@@ -198,6 +199,11 @@ class ArrowTableTrait(FixedErrorTraitType):
 
         # No restriction on the allowed geometry types in this table
         if allowed_geometry_types:
+            # If we allow polygons as input, then we also allow geoarrow.box.
+            # Convert boxes to Polygons
+            if EXTENSION_NAME.POLYGON in allowed_geometry_types:
+                value = parse_box_encoded_table(value)
+
             geometry_extension_type = value.schema.field(geom_col_idx).metadata.get(
                 b"ARROW:extension:name",
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ dev = [
     "pytest>=8.3.4",
     "ruff>=0.12.0",
     "sidecar>=0.7.0",
+    "types-geopandas>=1.1.1.20250708",
     "types-shapely>=2.1.0.20250512",
 ]
 # Note: this is defined as a separate group so that it can be not installed in

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -1,7 +1,7 @@
 import geoarrow.pyarrow as ga
-from arro3.core import Table
+from arro3.core import ChunkedArray, Table
 
-from lonboard import PolygonLayer, SolidPolygonLayer, viz
+from lonboard import Map, PolygonLayer, SolidPolygonLayer, viz
 
 
 def test_viz_box():
@@ -15,6 +15,31 @@ def test_viz_box():
 
     m = viz(arr)
     assert isinstance(m.layers[0], PolygonLayer)
+
+
+def test_box_polygon_layer():
+    arr = ga.box(
+        [
+            "LINESTRING (0 10, 34 -1)",
+            "LINESTRING (10 20, 44 -10)",
+            "LINESTRING (20 40, 54 5)",
+        ],
+    )
+    layer = PolygonLayer(arr)
+    _m = Map(layer)
+
+
+def test_box_polygon_layer_chunked_array():
+    arr = ga.box(
+        [
+            "LINESTRING (0 10, 34 -1)",
+            "LINESTRING (10 20, 44 -10)",
+            "LINESTRING (20 40, 54 5)",
+        ],
+    )
+    ca = ChunkedArray([arr])
+    layer = PolygonLayer(ca)
+    _m = Map(layer)
 
 
 def test_viz_box_polygon_layer():

--- a/uv.lock
+++ b/uv.lock
@@ -2161,6 +2161,7 @@ dev = [
     { name = "pytest" },
     { name = "ruff" },
     { name = "sidecar" },
+    { name = "types-geopandas" },
     { name = "types-shapely" },
 ]
 docs = [
@@ -2215,6 +2216,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "ruff", specifier = ">=0.12.0" },
     { name = "sidecar", specifier = ">=0.7.0" },
+    { name = "types-geopandas", specifier = ">=1.1.1.20250708" },
     { name = "types-shapely", specifier = ">=2.1.0.20250512" },
 ]
 docs = [
@@ -4255,6 +4257,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "types-geopandas"
+version = "1.1.1.20250708"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pandas-stubs", version = "2.2.2.240807", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pandas-stubs", version = "2.3.0.250703", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyproj", version = "3.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyproj", version = "3.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "types-shapely" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/72/4c461033d8b6b6c959b487aecef2277ffeadebb766e97bb6b0da84f8561a/types_geopandas-1.1.1.20250708.tar.gz", hash = "sha256:276942267558af0a5288a29a9054509c7d03cc00944174406ee4c815c4e65e7c", size = 23395, upload-time = "2025-07-08T03:15:11.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/04/59dc29f8c80cd8f98387584365b75b74bbcbf6680b8e24e6245ac7f6ebeb/types_geopandas-1.1.1.20250708-py3-none-any.whl", hash = "sha256:cf5153d40f18aa007718227955b6f1e31ceff4afcf914fa6ef00b1692848e2cd", size = 31796, upload-time = "2025-07-08T03:15:10.755Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Change list

- Implement `total_bounds` and `weighted_centroid` for `geoarrow.box` arrays
- Always add positional row index when the user passes in a raw array or chunked array
- Convert a geoarrow box column to a geoarrow polygon column in the table trait validation directly.
- Add new tests for passing `geoarrow.box` array and chunked array into `PolygonLayer` constructor.


Closes https://github.com/developmentseed/lonboard/issues/823