### PR TITLE
docs: Update examples referencing '_height'

### DIFF
--- a/examples/air-traffic-control.ipynb
+++ b/examples/air-traffic-control.ipynb
@@ -134,8 +134,8 @@
     "        \"pitch\": 50.6,\n",
     "        \"bearing\": 8.24,\n",
     "    },\n",
-    "    # Increase height of generated map (API subject to change)\n",
-    "    _height=800,\n",
+    "    # Increase height of generated map\n",
+    "    height=800,\n",
     ")\n",
     "m"
    ]

--- a/examples/ais-movingpandas.ipynb
+++ b/examples/ais-movingpandas.ipynb
@@ -309,7 +309,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m = Map(trips_layer, _height=600)\n",
+    "m = Map(trips_layer, height=600)\n",
     "m"
    ]
   },

--- a/examples/internet-speeds.ipynb
+++ b/examples/internet-speeds.ipynb
@@ -221,7 +221,7 @@
    "outputs": [],
    "source": [
     "layer = ScatterplotLayer.from_geopandas(gdf)\n",
-    "m = Map(layer, _height=800)\n",
+    "m = Map(layer, height=800)\n",
     "with sidecar:\n",
     "    display(m)"
    ]

--- a/examples/map_challenge/1-points.ipynb
+++ b/examples/map_challenge/1-points.ipynb
@@ -931,7 +931,7 @@
    ],
    "source": [
     "layer = ScatterplotLayer.from_geopandas(gdf)\n",
-    "map = Map(layers=[layer], _height=800)\n",
+    "map = Map(layers=[layer], height=800)\n",
     "map"
    ]
   },

--- a/examples/overture-geoparquet.ipynb
+++ b/examples/overture-geoparquet.ipynb
@@ -428,7 +428,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m = Map(layers, _height=600, basemap_style=CartoBasemap.DarkMatter)"
+    "m = Map(layers, height=600, basemap_style=CartoBasemap.DarkMatter)"
    ]
   },
   {
@@ -524,7 +524,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viz(data, map_kwargs={\"_height\": 600})"
+    "viz(data, map_kwargs={\"height\": 600})"
    ]
   },
   {


### PR DESCRIPTION
Updated the examples to reference `height` of maps now that it has replaced `_height`

closes #849 