### PR TITLE
docs: Don't run mkdocs-jupyter on py files

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -159,7 +159,7 @@ plugins:
       canonical_version: "latest"
   - mkdocs-jupyter:
       include_source: true
-      ignore: ["**/.ipynb_checkpoints/*.ipynb"]
+      ignore: ["*.py", "**/.ipynb_checkpoints/*.ipynb"]
       enabled: !ENV [CI, false]
   - mkdocstrings:
       enable_inventory: true


### PR DESCRIPTION
Turns out mkdocs-jupyter is clobbering the marimo example added in #881 

<img width="697" height="530" alt="image" src="https://github.com/user-attachments/assets/4c094b94-ec0d-4b25-90df-d45565e82ae4" />
