### PR TITLE
fix DataFilterExtension get_filter_category

### DIFF
--- a/examples/!category_filter.ipynb
+++ b/examples/!category_filter.ipynb
@@ -1,0 +1,141 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ffdeba2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f45976dba1f541268fa76936193821c3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(Map(basemap_style=<CartoBasemap.DarkMatter: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-st…"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# no intention of actually keeping this notebook in the repo, once it's all working good I'll make up a new doc about the category_filter\n",
+    "# I have added it for now to demonstrate that I've got the data filter filter_categories functionality working for numeric inputs\n",
+    "# looking at the deck gl docs: https://deck.gl/docs/api-reference/extensions/data-filter-extension#layer-properties\n",
+    "# it appears that we should be able to use strings for the categories but when I try to use string data the layer simply doesnt work\n",
+    "\n",
+    "import geopandas as gpd\n",
+    "import ipywidgets\n",
+    "import pyarrow as pa\n",
+    "from shapely.geometry import Point\n",
+    "\n",
+    "import lonboard\n",
+    "from lonboard.basemap import CartoBasemap\n",
+    "from lonboard.layer_extension import DataFilterExtension\n",
+    "\n",
+    "cat_col = \"int_col\"\n",
+    "# int_col: works\n",
+    "# float_col: works\n",
+    "# str_col: does NOT work :(\n",
+    "#  as is it will throw an arro3 ValueError: Expected object with __arrow_c_array__ method or implementing buffer protocol.\n",
+    "#  we can avoid the arro3 exception by using pyarrow as the input to get_filter_category when we create the layer:\n",
+    "#    `get_filter_category=pa.array(gdf[cat_col])`\n",
+    "#  but the layer doesn't display and throws a lot of the following WebGL error:\n",
+    "#   GL_INVALID_OPERATION: Vertex shader input type does not match the type of the bound vertex attribute\n",
+    "\n",
+    "\n",
+    "d = {\n",
+    "    \"int_col\": [0, 1, 2, 3, 4, 5],\n",
+    "    \"float_col\": [0.0, 1.5, 0.0, 1.5, 0.0, 1.5],\n",
+    "    \"str_col\": [\"even\", \"odd\", \"even\", \"odd\", \"even\", \"odd\"],\n",
+    "    \"geometry\": [\n",
+    "        Point(0, 0),\n",
+    "        Point(1, 1),\n",
+    "        Point(2, 2),\n",
+    "        Point(3, 3),\n",
+    "        Point(4, 4),\n",
+    "        Point(5, 5),\n",
+    "    ],\n",
+    "}\n",
+    "gdf = gpd.GeoDataFrame(d, crs=\"EPSG:4326\")\n",
+    "\n",
+    "point_layer = lonboard.ScatterplotLayer.from_geopandas(\n",
+    "    gdf,\n",
+    "    get_fill_color=(0, 255, 0),\n",
+    "    radius_min_pixels=10,\n",
+    "    extensions=[\n",
+    "        DataFilterExtension(filter_size=0, category_size=1)\n",
+    "    ],  # no range filter, just a category\n",
+    "    get_filter_category=gdf[cat_col],  # use the cat column for the filter category\n",
+    ")\n",
+    "\n",
+    "m = lonboard.Map(layers=[point_layer], basemap_style=CartoBasemap.DarkMatter)\n",
+    "\n",
+    "filter_enabled_w = ipywidgets.Checkbox(\n",
+    "    value=True,\n",
+    "    description=\"Filter Enabled\",\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def on_filter_enabled_change(change):  # noqa\n",
+    "    # when we change the checkbox, toggle filtering on the layer\n",
+    "    point_layer.filter_enabled = filter_enabled_w.value\n",
+    "\n",
+    "\n",
+    "filter_enabled_w.observe(on_filter_enabled_change, names=\"value\")\n",
+    "\n",
+    "cat_selector = ipywidgets.SelectMultiple(  # make a select multiple so we can see interaction on the map\n",
+    "    options=list(gdf[cat_col].unique()),\n",
+    "    value=[list(gdf[cat_col].unique())[0]],\n",
+    "    description=\"Category\",\n",
+    "    disabled=False,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def on_cat_selector_change(change) -> None:  # noqa\n",
+    "    # when we change the selector, update the filter on the layer.\n",
+    "    point_layer.filter_categories = cat_selector.value\n",
+    "\n",
+    "\n",
+    "cat_selector.observe(on_cat_selector_change, names=\"value\")\n",
+    "\n",
+    "ipywidgets.VBox([m, filter_enabled_w, cat_selector])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce25544c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf[\"number\"].values[0].item()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "lonboard_category_filter",
+   "language": "python",
+   "name": "lonboard_category_filter"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/lonboard/layer_extension.py
+++ b/lonboard/layer_extension.py
@@ -5,6 +5,7 @@ import traitlets as t
 from lonboard._base import BaseExtension
 from lonboard.traits import (
     DashArrayAccessor,
+    FilterCategoryAccessor,
     FilterValueAccessor,
     FloatAccessor,
     PointAccessor,
@@ -353,10 +354,12 @@ class DataFilterExtension(BaseExtension):
         "filter_transform_size": t.Bool(default_value=True).tag(sync=True),
         "filter_transform_color": t.Bool(default_value=True).tag(sync=True),
         "get_filter_value": FilterValueAccessor(default_value=None, allow_none=True),
-        "get_filter_category": FilterValueAccessor(default_value=None, allow_none=True),
+        "get_filter_category": FilterCategoryAccessor(
+            default_value=None, allow_none=True,
+        ),
     }
 
-    filter_size = t.Int(None, min=1, max=4, allow_none=True).tag(sync=True)
+    filter_size = t.Int(None, min=0, max=4, allow_none=True).tag(sync=True)
     """The size of the filter (number of columns to filter by).
 
     The data filter can show/hide data based on 1-4 numeric properties of each object.
@@ -365,7 +368,7 @@ class DataFilterExtension(BaseExtension):
     - Default 1.
     """
 
-    category_size = t.Int(None, min=1, max=4, allow_none=True).tag(sync=True)
+    category_size = t.Int(None, min=0, max=4, allow_none=True).tag(sync=True)
     """The size of the category filter (number of columns to filter by).
 
     The category filter can show/hide data based on 1-4 properties of each object.

--- a/src/model/extension.ts
+++ b/src/model/extension.ts
@@ -146,11 +146,18 @@ export class DataFilterExtension extends BaseExtensionModel {
   }
 
   extensionInstance(): _DataFilterExtension | null {
-    if (isDefined(this.filterSize)) {
+    if (isDefined(this.filterSize) && isDefined(this.categorySize)) {
+      const props = {
+        ...(isDefined(this.filterSize) ? { filterSize: this.filterSize } : {}),
+        ...(isDefined(this.categorySize)
+          ? { categorySize: this.categorySize }
+          : {}),
+      };
+      return new _DataFilterExtension(props);
+    } else if (isDefined(this.filterSize)) {
       const props = {
         ...(isDefined(this.filterSize) ? { filterSize: this.filterSize } : {}),
       };
-      // console.log("ext props", props);
       return new _DataFilterExtension(props);
     } else if (isDefined(this.categorySize)) {
       const props = {
@@ -158,7 +165,6 @@ export class DataFilterExtension extends BaseExtensionModel {
           ? { categorySize: this.categorySize }
           : {}),
       };
-      // console.log("ext props", props);
       return new _DataFilterExtension(props);
     } else {
       return null;


### PR DESCRIPTION
as we discussed in discussion #711 I was unable to get the DataFilterExtension to work for filtering data with categories.

I finally spent some time looking into what was going on, and the `FilterValueAccessor` was being used for the get_filter_category property, but that accessor is set up to work in conjunction with the `filter_size` parameter of the DataFilterExtension.  I  created a new `FilterCategoryAccessor` accessor modeled after the `FilterValueAccessor` that works with the `category_size` parameter and does not do any casting of values to Float32, because looking at the DeckGL docs it appears that the category_filter should be able to work with string data.

Using the new accessor for the get_filter_category  on the data filter extension I'm now able to change `filter_categories` on the layer and the features are filtered as expected for numeric data.  What I've got still isn't working for filtering with string data, but I figured this was worth throwing out there to see if anyone else had an idea how to get the filter working with those as well.

I've added a notebook to the examples folder that I do not intend to actually check into the repo, which creates a DFE for a layer and links it to a widget to show that the category_filter is working for the numeric data, but not the string data.  If we get the strings working I'd be happy to make a better example notebook that showcases category filters