### PR TITLE
feat: Suppress JupyterLab context menu on Map right click

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -215,7 +215,14 @@ function App() {
   );
 
   return (
-    <div className="lonboard" style={{ minHeight: "100%", height: mapHeight }}>
+    <div
+      className="lonboard"
+      style={{ minHeight: "100%", height: mapHeight }}
+      // This attribute suppresses the context menu on right click in JupyterLab
+      // https://jupyterlab.readthedocs.io/en/latest/extension/extension_points.html#context-menu
+      // https://jupyter.zulipchat.com/#narrow/channel/471314-geojupyter/topic/Possible.20to.20disable.20JupyterLab.20popup.20on.20right.20click.3F/near/541082696
+      data-jp-suppress-context-menu
+    >
       <div
         id={`map-${mapId}`}
         className="flex"


### PR DESCRIPTION
The `data-jp-suppress-context-menu` attribute suppresses the context menu on right click in JupyterLab
https://jupyterlab.readthedocs.io/en/latest/extension/extension_points.html#context-menu
https://jupyter.zulipchat.com/#narrow/channel/471314-geojupyter/topic/Possible.20to.20disable.20JupyterLab.20popup.20on.20right.20click.3F/near/541082696

Before:

https://github.com/user-attachments/assets/75bd2120-2099-4a3d-a74b-7618c7c1e7b6

After:

https://github.com/user-attachments/assets/eec0b68b-cfe7-4117-8160-53f29215001e

Note that _on its own_, this is not that much different, as it shows the native browser modal instead of the JupyterLab modal. But when we switch to using `MapboxOverlay`, that will then allow panning with a `ctrl` or right click:

https://github.com/user-attachments/assets/41cafd67-ee73-4578-8625-d5ad6d85ccf0

