### PR TITLE
feat: Switch to using MapboxOverlay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "@deck.gl/core": "^9.1.14",
         "@deck.gl/extensions": "^9.1.14",
         "@deck.gl/layers": "^9.1.14",
+        "@deck.gl/mapbox": "^9.1.14",
         "@deck.gl/react": "^9.1.14",
         "@geoarrow/deck.gl-layers": "^0.3.1",
         "@nextui-org/react": "^2.4.8",
@@ -1396,6 +1397,19 @@
       "integrity": "sha512-YA/9PzaCRHbIP5/0E9uTYrqe+jsYTQoqoDWhf6/b0Ixz8bPZBaGDEafLg3z7ffBomZLacUty9U3TlPjqMtzPjA==",
       "dependencies": {
         "@math.gl/core": "4.1.0"
+      }
+    },
+    "node_modules/@deck.gl/mapbox": {
+      "version": "9.1.14",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mapbox/-/mapbox-9.1.14.tgz",
+      "integrity": "sha512-l3c5NFwKjIOeVWMtqK5LR8MA4grRe7tpLctkovNIo+owPBoW+q7gAWBJ1hGFmE1sxVFhoqZx70FqBAT9Mqn1ow==",
+      "dependencies": {
+        "@luma.gl/constants": "~9.1.9",
+        "@math.gl/web-mercator": "^4.1.0"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "^9.1.0",
+        "@luma.gl/core": "~9.1.9"
       }
     },
     "node_modules/@deck.gl/mesh-layers": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@deck.gl/extensions": "^9.1.14",
     "@deck.gl/layers": "^9.1.14",
     "@deck.gl/react": "^9.1.14",
+    "@deck.gl/mapbox": "^9.1.14",
     "@geoarrow/deck.gl-layers": "^0.3.1",
     "@babel/runtime": "^7.28.4",
     "@nextui-org/react": "^2.4.8",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,12 @@ import * as React from "react";
 import { useEffect, useCallback, useState } from "react";
 import { createRender, useModelState, useModel } from "@anywidget/react";
 import type { Initialize, Render } from "@anywidget/types";
-import Map, { useControl } from "react-map-gl/maplibre";
+import Map, {
+  useControl,
+  FullscreenControl,
+  NavigationControl,
+  ScaleControl,
+} from "react-map-gl/maplibre";
 import { MapViewState, PickingInfo, type Layer } from "@deck.gl/core";
 import { BaseLayerModel, initializeLayer } from "./model/index.js";
 import type { WidgetModel } from "@jupyter-widgets/base";
@@ -249,7 +254,6 @@ function App() {
         <div className="bg-red-800 h-full w-full relative">
           <Map
             reuseMaps
-            // projection="globe"
             id={`map-${mapId}`}
             initialViewState={
               ["longitude", "latitude", "zoom"].every((key) =>
@@ -258,19 +262,14 @@ function App() {
                 ? initialViewState
                 : DEFAULT_INITIAL_VIEW_STATE
             }
-            // boxZoom={false}
-            // dragRotate={false}
-            // maxPitch={0}
             mapStyle={mapStyle || DEFAULT_MAP_STYLE}
-            attributionControl={{ customAttribution }}
-            onContextMenu={(e) => {
-              console.log("hi");
-
-              e.originalEvent.stopPropagation();
-              // e.stopPropagation();
-              e.preventDefault();
+            attributionControl={{
+              customAttribution,
             }}
           >
+            <FullscreenControl position="top-left" />
+            <NavigationControl position="top-left" />
+            <ScaleControl position="bottom-left" />
             <DeckGLOverlay
               // interleaved
               style={{ width: "100%", height: "100%" }}


### PR DESCRIPTION
This revisits and supersedes https://github.com/developmentseed/lonboard/pull/437. 


### Change list

- Add `@deck.gl/mapbox` dependency
- Add `FullscreenControl` and `NavigationControl`. These are placed on the top-left of the map for now, because the bounding box selection is already on the top right. But perhaps we should move the bbox selection to the left side? 🤷‍♂️ 


### Questions

- Does it make sense to use controls from _Maplibre_ instead of the related "widgets" from Deck.gl v9? 

See also more background information in https://github.com/developmentseed/lonboard/pull/437:

> There's a wider question here: should Maplibre be a child of Deck or should Deck be a child of Maplibre? The Deck docs list [some limitations](https://deck.gl/docs/api-reference/mapbox/overview#limitations):
> 
> > * When using deck.gl's multi-view system, only one of the views can match the base map and receive interaction. See [using MapboxOverlay with multi-views](./mapbox-overlay.md#multi-view-usage) for details.
> > * When using deck.gl as Mapbox layers or controls, `Deck` only receives a subset of user inputs delegated by `Map`. Therefore, certain interactive callbacks like `onDrag`, `onInteractionStateChange` are not available.
> > * Mapbox/Maplibre's terrain features are partially supported. When a terrain is used, the camera of deck.gl and the base map should synchronize, however the deck.gl data with z=0 are rendered at the sea level and not aligned with the terrain surface.
> > * Only Mercator projection is supported. Mapbox adaptive projection is not supported as their API doesn't expose the projection used.
> > * The `position` property in `viewState` has no equivalent in mapbox-gl.
> 
> #### Maplibre as a child of Deck (not using MapboxOverlay)
> * We should be able to have more low level control over visualization and be less tied to maplibre.
> * For example, it would be really cool to visualize a side-by-side map, where you could swipe to see a before-and-after with two datasets. This option is required for this feature. Otherwise, when using `MapboxOverlay` [you can't have multiple interactive deck views](https://deck.gl/docs/api-reference/mapbox/mapbox-overlay#multi-view-usage).
> * This also would keep us less tied to geospatial. So in theory non-geospatial users could use lonboard without a basemap, and still get to use all of lonboard's utilities for data serialization.
> 
> #### Deck as a child of Maplibre (using MapboxOverlay)
> * Can use all Maplibre and Maplibre-compatible controls. In theory this should even include things like [mapbox-gl-draw](https://github.com/mapbox/mapbox-gl-draw). ([Upstream example](https://docs.mapbox.com/mapbox-gl-js/example/mapbox-gl-draw/)). In theory we wouldn't have to write our own, like we're doing in [Select by bounding box #417](https://github.com/developmentseed/lonboard/pull/417)
> * Note that `fly_to` is now broken. This is because deck is no longer maintaining the view state itself.

I think eventually it may make sense to allow rendering deck.gl without any sort of geospatial basemap, but that's a future topic.

Closes https://github.com/developmentseed/lonboard/issues/436, closes https://github.com/developmentseed/lonboard/issues/842