### PR TITLE
fix: Fix rendering from model hooks

### DIFF
--- a/src/hooks/basemap.ts
+++ b/src/hooks/basemap.ts
@@ -41,7 +41,7 @@ export function useBasemapState(
     };
 
     loadBasemap();
-  }, [basemapModelId, widgetManager, updateStateCallback]);
+  }, [basemapModelId]);
 
   return basemapState;
 }

--- a/src/hooks/layers.ts
+++ b/src/hooks/layers.ts
@@ -56,14 +56,7 @@ export function useLayersState(
     };
 
     loadAndUpdateLayers();
-  }, [
-    layerIds,
-    bboxSelectBounds,
-    isDrawingBBoxSelection,
-    widgetManager,
-    updateStateCallback,
-    setSelectedBounds,
-  ]);
+  }, [layerIds, bboxSelectBounds, isDrawingBBoxSelection]);
 
   return Object.values(layersState).flatMap((layerModel) =>
     layerModel.render(),

--- a/src/hooks/views.ts
+++ b/src/hooks/views.ts
@@ -47,7 +47,7 @@ export function useViewsState(
     };
 
     loadAndUpdateViews();
-  }, [viewIds, widgetManager, updateStateCallback]);
+  }, [viewIds]);
 
   const views = Object.values(viewsState).map((viewModel) => viewModel.build());
 


### PR DESCRIPTION
This last commit was supposed to go in https://github.com/developmentseed/lonboard/pull/971 🤦‍♂️ 

Having the functional callbacks in `deps` causes the app to crash the browser, because the function compares not equal to itself, so the hook re-runs on every render.