### PR TITLE
fix: Fix define stringify in build config

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -15,7 +15,7 @@ const node_env = process.env.NODE_ENV || "production";
 const defineEnv = {
   // Ref https://github.com/manzt/anywidget/issues/369#issuecomment-1792376003
   "define.amd": "false",
-  "process.env.NODE_ENV": node_env,
+  "process.env.NODE_ENV": JSON.stringify(node_env),
   "process.env.XSTATE_INSPECT": JSON.stringify(
     process.env.XSTATE_INSPECT || "false",
   ),


### PR DESCRIPTION
After #981 I got an error:

> ▲ [WARNING] "process.env.NODE_ENV" is defined as an identifier instead of a string (surround "development" with quotes to get a string) [suspicious-define]

According to chatgpt:

> The define option replaces expressions at build time, so it’s a literal text substitution. That means you must pass a valid JS expression as a string, not an identifier.

Therefore we need to pass `JSON.stringify` into the input.