### PR TITLE
perf: Remove typedArrayManager settings override

### DIFF
--- a/src/renderers/deck-first.tsx
+++ b/src/renderers/deck-first.tsx
@@ -29,11 +29,6 @@ const DeckFirstRenderer: React.FC<MapRendererProps & DeckFirstRendererProps> = (
       ref={deckRef}
       style={{ width: "100%", height: "100%" }}
       controller={true}
-      // https://deck.gl/docs/api-reference/core/deck#_typedarraymanagerprops
-      _typedArrayManagerProps={{
-        overAlloc: 1,
-        poolSize: 0,
-      }}
       {...deckProps}
     >
       {controls.map((control) => control.renderDeck())}

--- a/src/renderers/overlay.tsx
+++ b/src/renderers/overlay.tsx
@@ -47,14 +47,7 @@ const OverlayRenderer: React.FC<MapRendererProps & OverlayRendererProps> = (
       {...(isGlobeView(views) && { projection: "globe" })}
     >
       {controls.map((control) => control.renderMaplibre())}
-      <DeckGLOverlay
-        // https://deck.gl/docs/api-reference/core/deck#_typedarraymanagerprops
-        _typedArrayManagerProps={{
-          overAlloc: 1,
-          poolSize: 0,
-        }}
-        {...deckProps}
-      />
+      <DeckGLOverlay {...deckProps} />
     </Map>
   );
 };


### PR DESCRIPTION
In #917 I documented some performance issues during rendering.

Removing these settings for `typedArrayManagerProps` fixes the rendering performance.

The issue is that we were never using deck.gl to allocate data before this layer. So I essentially turned off the typed array manager to avoid any extra memory usage.

But with the H3Layer, we're now passing h3 strings to deck.gl and letting deck.gl manage the geometry construction. This means that with the typed array manager turned off we were getting massive performance hits to allocations and GC.

Also improves perf of the [upcoming A5Layer](https://github.com/developmentseed/lonboard/pull/1001)

cc @felixpalmer 