### PR TITLE
chore: Rename `views` Map attribute to `view`

### DIFF
--- a/lonboard/_map.py
+++ b/lonboard/_map.py
@@ -212,7 +212,7 @@ class Map(BaseAnyWidget):
     )
     """One or more map controls to display on this map."""
 
-    views: t.Instance[BaseView | None] = t.Instance(BaseView, allow_none=True).tag(
+    view: t.Instance[BaseView | None] = t.Instance(BaseView, allow_none=True).tag(
         sync=True,
         **ipywidgets.widget_serialization,
     )
@@ -675,7 +675,7 @@ class Map(BaseAnyWidget):
 
     @traitlets.default("view_state")
     def _default_initial_view_state(self) -> dict[str, Any]:
-        if isinstance(self.views, (MapView, GlobeView)):
+        if isinstance(self.view, (MapView, GlobeView)):
             return compute_view(self.layers)  # type: ignore
 
         return {}

--- a/lonboard/basemap.py
+++ b/lonboard/basemap.py
@@ -160,8 +160,6 @@ class MaplibreBasemap(BaseWidget):
 
         The reverse-controlled mode renders deck.gl above the MapLibre container and blocks any interaction to the base map.
 
-        If you need to have multiple views, you should use this option.
-
     **Default**: `"overlaid"`
     """
 

--- a/lonboard/traits/_map.py
+++ b/lonboard/traits/_map.py
@@ -83,7 +83,6 @@ class ViewStateTrait(FixedErrorTraitType):
         self.tag(sync=True, to_json=serialize_view_state)
 
     def validate(self, obj: Map, value: Any) -> None | BaseViewState:
-        view = obj.views
         if value is None:
             return None
 
@@ -91,5 +90,6 @@ class ViewStateTrait(FixedErrorTraitType):
             return value
 
         # Otherwise dict input
+        view = obj.view
         validator = view._view_state_type if view is not None else MapViewState  # noqa: SLF001
         return validator(**value)  # type: ignore

--- a/lonboard/types/map.py
+++ b/lonboard/types/map.py
@@ -10,8 +10,8 @@ else:
 
 if TYPE_CHECKING:
     from lonboard.basemap import MaplibreBasemap
-    from lonboard.models import BaseViewState
     from lonboard.view import BaseView
+    from lonboard.view_state import BaseViewState
 
 
 class MapKwargs(TypedDict, total=False):
@@ -24,5 +24,5 @@ class MapKwargs(TypedDict, total=False):
     show_tooltip: bool
     show_side_panel: bool
     use_device_pixels: int | float | bool
-    views: BaseView | list[BaseView] | tuple[BaseView, ...]
+    view: BaseView
     view_state: BaseViewState | dict[str, Any]

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -84,7 +84,7 @@ function App() {
   const [customAttribution] = useModelState<string>("custom_attribution");
   const [mapId] = useState(uuidv4());
   const [childLayerIds] = useModelState<string[]>("layers");
-  const [viewIds] = useModelState<string | string[] | null>("views");
+  const [viewIds] = useModelState<string | string[] | null>("view");
   const [controlsIds] = useModelState<string[]>("controls");
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [_selectedBounds, setSelectedBounds] = useModelState<number[] | null>(

--- a/src/model/view.ts
+++ b/src/model/view.ts
@@ -1,22 +1,24 @@
-import {
-  FirstPersonView,
+import type {
   FirstPersonViewProps,
   FirstPersonViewState,
-  _GlobeView as GlobeView,
   GlobeViewProps,
   GlobeViewState,
-  MapView,
   MapViewProps,
   MapViewState,
-  OrbitView,
   OrbitViewProps,
   OrbitViewState,
-  OrthographicView,
   OrthographicViewProps,
   OrthographicViewState,
+  View,
 } from "@deck.gl/core";
-import type { View } from "@deck.gl/core";
-import { CommonViewProps } from "@deck.gl/core/dist/views/view";
+import {
+  FirstPersonView,
+  _GlobeView as GlobeView,
+  MapView,
+  OrbitView,
+  OrthographicView,
+} from "@deck.gl/core";
+import type { CommonViewProps } from "@deck.gl/core/dist/views/view";
 import { WidgetModel } from "@jupyter-widgets/base";
 
 import { isDefined } from "../util";

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -78,13 +78,13 @@ def test_view_state_globe_view_dict():
         "latitude": 37.8,
         "zoom": 2.0,
     }
-    m = Map([], views=GlobeView(), view_state=view_state)
+    m = Map([], view=GlobeView(), view_state=view_state)
     assert m.view_state == GlobeViewState(**view_state)
 
 
 def test_view_state_globe_view_instance():
     view_state = GlobeViewState(longitude=-122.45, latitude=37.8, zoom=2.0)
-    m = Map([], views=GlobeView(), view_state=view_state)
+    m = Map([], view=GlobeView(), view_state=view_state)
     assert m.view_state == view_state
 
 
@@ -94,13 +94,13 @@ def test_view_state_first_person_dict():
         "latitude": 37.8,
         "position": [0, 0, 10],
     }
-    m = Map([], views=FirstPersonView(), view_state=view_state)
+    m = Map([], view=FirstPersonView(), view_state=view_state)
     assert m.view_state == FirstPersonViewState(**view_state)
 
 
 def test_view_state_orthographic_view_empty():
     view_state = {}
-    m = Map([], views=OrthographicView(), view_state=view_state)
+    m = Map([], view=OrthographicView(), view_state=view_state)
     assert m.view_state == OrthographicViewState(**view_state)
 
 
@@ -127,7 +127,7 @@ def test_set_view_state_partial_update():
 def test_globe_view_state_partial_update():
     m = Map(
         [],
-        views=GlobeView(),
+        view=GlobeView(),
         view_state={"longitude": -100, "latitude": 40, "zoom": 5},
     )
     m.set_view_state(latitude=45)
@@ -137,7 +137,7 @@ def test_globe_view_state_partial_update():
 def test_set_view_state_orbit():
     m = Map(
         [],
-        views=FirstPersonView(),
+        view=FirstPersonView(),
         view_state={"longitude": -100, "latitude": 40},
     )
     new_view_state = FirstPersonViewState(


### PR DESCRIPTION
In the upstream deck.gl code, the Map param is `views`, but we don't currently support multiple views. I think it'll be clearer to name this `view`, and, if at some point in the future, we support multiple views, then we can rename it to `views` at that point (but probably keep `view` as well for backwards compatibility)

Closes https://github.com/developmentseed/lonboard/issues/965