### PR TITLE
perf: Avoid generating str repr of `table` during rendering

### DIFF
--- a/lonboard/layer/_base.py
+++ b/lonboard/layer/_base.py
@@ -31,7 +31,7 @@ from lonboard.traits import ArrowTableTrait, VariableLengthTuple
 
 if TYPE_CHECKING:
     import sys
-    from collections.abc import Sequence
+    from collections.abc import Generator, Sequence
 
     import duckdb
     import geopandas as gpd
@@ -312,6 +312,17 @@ class BaseArrowLayer(BaseLayer):
     # The following traitlets **are** serialized to JS
 
     table: ArrowTableTrait
+
+    def _repr_keys(self) -> Generator[str, Any, None]:
+        # Avoid rendering `table` in the string repr
+        #
+        # By default, `_repr_mimebundle_` creates the rich HTML content **and** a plain
+        # text repr to show in environments that don't support rendering HTML. We want
+        # to avoid generating a str repr of any large values.
+        # https://github.com/developmentseed/lonboard/issues/1014
+        for key in super()._repr_keys():
+            if key != "table":
+                yield key
 
     def __init__(
         self,


### PR DESCRIPTION
What's happening here is that [`_repr_mimebundle_`](https://github.com/manzt/anywidget/blob/a49a872a9e2cd491e7597bc1e550d14352efc7b6/anywidget/widget.py#L76-L82) creates **both** the rich HTML content **and** a plain text repr to show in environments that don't support HTML rendering.

So it was taking 11.6 seconds to print the string repr of the Arrow table, just to generate the `_repr_mimebundle_`.

I'm not clear if this is a regression or just an unhandled bug on the arro3 side (https://github.com/kylebarron/arro3/issues/432). I think arro3 handles _long_ tables by taking the first and last `n` rows to print. But it clearly doesn't handle very _wide_ rows at all. 

### Change list

- This overrides [`_repr_keys`](https://github.com/jupyter-widgets/ipywidgets/blob/df7836eb4509283a0bf14d7b4ac92bc30c11fc76/python/ipywidgets/ipywidgets/widgets/widget.py#L827-L843) to ensure that the str repr of the `table` attribute is never generated. I think this is the only key that should be very slow.

### Benchmark

99.9% faster rendering 😅 

On this branch:

```py
from lonboard import viz
from geodatasets import get_path
import geopandas as gpd
from IPython.display import display

gdf = gpd.read_file(get_path("nybb"))

%%time
m = viz(gdf)
# CPU times: user 112 ms, sys: 28.3 ms, total: 141 ms
# Wall time: 148 ms

%%time
display(m)
# CPU times: user 5.01 ms, sys: 1.41 ms, total: 6.43 ms
# Wall time: 5.64 ms
```

On main:

```py
from lonboard import viz
from geodatasets import get_path
import geopandas as gpd
from IPython.display import display

gdf = gpd.read_file(get_path("nybb"))

%%time
m = viz(gdf)
# CPU times: user 112 ms, sys: 28.3 ms, total: 141 ms
# Wall time: 148 ms

%%time
display(m)
# CPU times: user 11.6 s, sys: 262 ms, total: 11.9 s
# Wall time: 12 s
```

Closes #1014 