### PR TITLE
fix: Fix import of BaseView

### DIFF
--- a/lonboard/types/map.py
+++ b/lonboard/types/map.py
@@ -10,7 +10,7 @@ else:
 
 if TYPE_CHECKING:
     from lonboard.basemap import MaplibreBasemap
-    from lonboard.view import BaseView
+    from lonboard.experimental.view import BaseView
     from lonboard.view_state import BaseViewState
 
 


### PR DESCRIPTION
This is in a `TYPE_CHECKING` block, so it's not urgent and it can wait until the next patch release