### PR TITLE
chore: align plausible analytics domain

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,7 @@ docs_dir: docs
 extra:
   analytics:
     provider: plausible
-    domain: developmentseed.org/lonboard
+    domain: developmentseed.org
     feedback:
       title: Was this page helpful?
       ratings:


### PR DESCRIPTION
Point MkDocs Plausible analytics at developmentseed.org so lonboard docs traffic is grouped with the shared site property.

This will make tracking analytics across our different pages underneath developmentseed.org easier for @kcarini