### PR TITLE
revert: restore lonboard plausible domain

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,7 @@ docs_dir: docs
 extra:
   analytics:
     provider: plausible
-    domain: developmentseed.org
+    domain: developmentseed.org/lonboard
     feedback:
       title: Was this page helpful?
       ratings:


### PR DESCRIPTION
Undo shared analytics domain grouping and restore the lonboard-specific Plausible domain value.

Apologies, I missed that Plausible has a consolidated site feature now. We'll use that and revert back to the old tracking method.