### PR TITLE
fix: add support for boolean data in apply_categorical_cmap

### DIFF
--- a/lonboard/colormap.py
+++ b/lonboard/colormap.py
@@ -203,6 +203,17 @@ def apply_categorical_cmap(  # noqa: C901
 
     values = ChunkedArray(values)
 
+    # Handle boolean arrays since dictionary_encode doesn't support boolean type
+    boolean_cmap_conversion = None
+    if DataType.is_boolean(values.type):
+        # Convert boolean values to strings for dictionary encoding
+        values_numpy = values.to_numpy(zero_copy_only=False)
+        string_values = np.where(values_numpy, "True", "False")
+        values = ChunkedArray(Array.from_numpy(string_values))
+        
+        # Create a mapping from string keys to boolean keys for colormap lookup
+        boolean_cmap_conversion = {str(k): k for k in cmap.keys() if isinstance(k, bool)}
+
     if not DataType.is_dictionary(values.type):
         values = ChunkedArray(dictionary_encode(values))
 
@@ -220,7 +231,11 @@ def apply_categorical_cmap(  # noqa: C901
         lut[:, 3] = 255
 
     for i, key in enumerate(dictionary):
-        color = cmap[key.as_py()]
+        key_py = key.as_py()
+        # If we converted boolean to string, map back to boolean for colormap lookup
+        if boolean_cmap_conversion and key_py in boolean_cmap_conversion:
+            key_py = boolean_cmap_conversion[key_py]
+        color = cmap[key_py]
 
         if isinstance(color, str):
             color = _to_rgba_no_colorcycle(color, alpha=alpha)

--- a/tests/test_colormap.py
+++ b/tests/test_colormap.py
@@ -1,3 +1,4 @@
+import numpy as np
 from arro3.core import Array, DataType
 
 from lonboard.colormap import apply_categorical_cmap
@@ -15,3 +16,22 @@ def test_discrete_cmap():
 
     for i, val in enumerate(str_values):
         assert list(colors[i]) == cmap[val]
+
+
+def test_discrete_cmap_boolean():
+    """Test that boolean values work with categorical colormap."""
+    bool_values = np.array([True, False, True, False])
+    cmap = {
+        True: [0, 255, 0],   # Green for True
+        False: [255, 0, 0],  # Red for False
+    }
+    colors = apply_categorical_cmap(bool_values, cmap)
+    
+    expected_colors = np.array([
+        [0, 255, 0],    # True -> green
+        [255, 0, 0],    # False -> red  
+        [0, 255, 0],    # True -> green
+        [255, 0, 0],    # False -> red
+    ], dtype=np.uint8)
+    
+    np.testing.assert_array_equal(colors, expected_colors)


### PR DESCRIPTION
## Problem

Using `apply_categorical_cmap` with boolean data throws an error:

```
Exception: C Data interface error: C Data interface error: Compute error: Boolean not supported in rank
```

This happens because the underlying `arro3.compute.dictionary_encode` function doesn't support boolean arrays.

## Solution

Added support for boolean arrays by:

1. **Detection**: Check if input values are boolean type before dictionary encoding
2. **Conversion**: Convert boolean values to strings ('True'/'False') for dictionary encoding
3. **Mapping**: Create a reverse mapping to convert string keys back to boolean keys during colormap lookup
4. **Preservation**: Maintain the original boolean-based colormap interface

## Example Usage

```python
import numpy as np
from lonboard.colormap import apply_categorical_cmap

# This now works without errors
values = np.array([True, False, True, False])
cmap = {True: [0, 255, 0], False: [255, 0, 0]}
colors = apply_categorical_cmap(values, cmap)
```

## Testing

Added test case `test_discrete_cmap_boolean()` to verify boolean values work correctly and produce the expected color mapping.

The fix is backward compatible and doesn't affect existing functionality with string, numeric, or other supported data types.

Fixes #1122

Greetings, saschabuehrle