### PR TITLE
docs: fix logo in docs

### DIFF
--- a/docs/blog/posts/lonboard-0.15.md
+++ b/docs/blog/posts/lonboard-0.15.md
@@ -23,7 +23,7 @@ Refer to the [changelog] for all updates.
 
 Lonboard has a new logo!
 
-<img src="../../assets/lonboard-logo.png" width="400" />
+![](../../assets/lonboard-logo.png)
 
 This logo was designed by [Gus Becker], and continues with the pun behind Lonboard:
 


### PR DESCRIPTION
I guess the paths didn't work out in an img tag.

<img width="317" height="217" alt="image" src="https://github.com/user-attachments/assets/c6227f68-e3a1-404e-9293-b5a4826e8313" />
