### PR TITLE
ci: Set up trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,16 @@ jobs:
           path: ./dist/
 
   upload_pypi:
+    name: Upload release to PyPI
     needs: [build]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
+    environment:
+      # Note: this environment must be configured in the repo settings
+      name: pypi-release
+      url: https://pypi.org/p/lonboard
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -58,8 +66,8 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          # To test: repository_url: https://test.pypi.org/legacy/
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # Optional: test upload to Test PyPI instead of production PyPI
+        # with:
+        #   repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Set up trusted publishing to avoid needing to use long-lived tokens for publishing