### PR TITLE
feat: RasterLayer: better printing of exceptions from render_tile

### DIFF
--- a/lonboard/_exception_display.py
+++ b/lonboard/_exception_display.py
@@ -3,6 +3,25 @@
 from ipywidgets import Output
 
 
+class OutputProxy:
+    """A file-like proxy that routes writes to an ErrorOutput's stdout or stderr."""
+
+    def __init__(self, output: "ErrorOutput", *, is_stderr: bool) -> None:
+        self._output = output
+        self._is_stderr = is_stderr
+
+    def write(self, text: str) -> int:
+        if text:
+            if self._is_stderr:
+                self._output.append_stderr(text)
+            else:
+                self._output.append_stdout(text)
+        return len(text)
+
+    def flush(self) -> None:
+        pass
+
+
 class ErrorOutput(Output):
     """An Output widget that captures and displays error messages."""
 
@@ -24,3 +43,11 @@ class ErrorOutput(Output):
 
     def append_stderr(self, text: str) -> None:
         return super().append_stderr(self._prepare_text(text))
+
+    def open_stdout(self) -> OutputProxy:
+        """Return a file-like object that writes to this widget's stdout."""
+        return OutputProxy(self, is_stderr=False)
+
+    def open_stderr(self) -> OutputProxy:
+        """Return a file-like object that writes to this widget's stderr."""
+        return OutputProxy(self, is_stderr=True)

--- a/lonboard/layer/_raster.py
+++ b/lonboard/layer/_raster.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import traceback
+from contextlib import redirect_stderr, redirect_stdout
 from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar, Unpack
 
 from pyproj.transformer import Transformer
@@ -113,24 +114,28 @@ async def _handle_tile_request(
 ) -> None:
     """Async handler for tile data requests from the frontend."""
     output = widget._error_output
+    content = msg.get("msg", {})
+    tile = content.get("tile", {})
+    index = tile.get("index", {})
+    x = index.get("x")
+    y = index.get("y")
+    z = index.get("z")
 
     try:
         if widget.debug:
             output.append_stdout(f"Received tile request: {msg}")
 
-        content = msg["msg"]
-        tile = content["tile"]
-        index = tile["index"]
-        x = index["x"]
-        y = index["y"]
-        z = index["z"]
-
         if widget.debug:
             output.append_stdout(f"Fetching tile at x={x}, y={y}, z={z}\n")
 
-        tile = await widget._fetch_tile(x=x, y=y, z=z)
+        loaded_tile = await widget._fetch_tile(x=x, y=y, z=z)
+
         # TODO: put rendering in thread pool?
-        rendered = widget._render_tile(tile)
+        with (
+            redirect_stdout(output.open_stdout()),  # type: ignore
+            redirect_stderr(output.open_stderr()),  # type: ignore
+        ):
+            rendered = widget._render_tile(loaded_tile)
         if rendered is None:
             widget.send(
                 {
@@ -158,7 +163,9 @@ async def _handle_tile_request(
         )
     except Exception:  # noqa: BLE001
         error_msg = traceback.format_exc()
-        output.append_stderr(f"Error handling tile request: {error_msg}\n")
+        output.append_stderr(
+            f"Error handling tile request for input {tile}\n: {error_msg}\n",
+        )
 
         widget.send(
             {


### PR DESCRIPTION
- It's easy for `render_tile` to fail with some sort of exception. We now print the tile where the exception came from.
- Also, if the user calls `print` from inside the `render_tile`, it'll show beneath the map element. (at least when `debug=True` is set on the layer)