### PR TITLE
fix: overture-geoparquet example

### DIFF
--- a/examples/overture-geoparquet.ipynb
+++ b/examples/overture-geoparquet.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57e4678a",
+   "id": "0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,7 +28,7 @@
     }
    },
    "cell_type": "markdown",
-   "id": "250a25da-9547-4a0a-b709-8659e0669545",
+   "id": "1",
    "metadata": {},
    "source": [
     "# Spatially-Partitioned GeoParquet\n",
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "665edcb2-b546-435e-ba77-7ea651ab6ae6",
+   "id": "2",
    "metadata": {},
    "source": [
     "## Dependencies\n",
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62c1bef5-071e-4cf0-98e4-2e70171c3006",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Imports\n"
@@ -69,7 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9ae52a41",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,6 +77,7 @@
     "import shapely\n",
     "from arro3.core import Array, DataType, Table\n",
     "from geoarrow.rust.io import GeoParquetDataset\n",
+    "import obstore as obs\n",
     "from obstore.store import S3Store\n",
     "\n",
     "from lonboard import Map, PolygonLayer, viz\n",
@@ -85,15 +86,58 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8750bec6-4962-4006-bfd2-0bf084fd2041",
+   "id": "5",
    "metadata": {},
    "source": [
-    "## Accessing Overture data on Cloud Storage\n"
+    "## Accessing Overture data on Cloud Storage"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1f86a07a-a118-4ab4-8be6-c72c40467924",
+   "id": "6",
+   "metadata": {},
+   "source": [
+    "Getting latest Overture data on AWS S3 by listing the releases in the bucket first and choosing one. \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "store = S3Store.from_url(\n",
+    "    \"s3://overturemaps-us-west-2\",\n",
+    "    region=\"us-west-2\",\n",
+    "    skip_signature=True,\n",
+    ")\n",
+    "\n",
+    "result = obs.list_with_delimiter(store, prefix=\"release\")\n",
+    "latest = sorted(result[\"common_prefixes\"])[-1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "Latest Overture release prefix:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "latest"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10",
    "metadata": {},
    "source": [
     "We'll create an [S3Store](https://developmentseed.org/obstore/latest/api/store/aws/#obstore.store.S3Store) to access Overture data on AWS S3.\n"
@@ -102,20 +146,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32f354d5",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
-    "store = S3Store.from_url(\n",
-    "    \"s3://overturemaps-us-west-2/release/2025-06-25.0/\",\n",
-    "    region=\"us-west-2\",\n",
-    "    skip_signature=True,\n",
-    ")"
+    "store = S3Store.from_url(                                                                                                                                                  \n",
+    "      f\"s3://overturemaps-us-west-2/{latest}/\",                                                                                                                              \n",
+    "      region=\"us-west-2\",                                                                                                                                                    \n",
+    "      skip_signature=True,                                                                                                                                                   \n",
+    "  )"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "7d36e0f2-7dc6-4ea0-9200-f5ffb205adc1",
+   "id": "12",
    "metadata": {},
    "source": [
     "Overture has [two official copies](https://docs.overturemaps.org/getting-data/#official-overture-sources) of their distribution: one on AWS and another on Azure Storage.\n",
@@ -126,21 +170,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2b03c383-b0b8-4c0f-b057-af77357239d1",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
     "# from obstore.store import AzureStore\n",
-    "#\n",
+    "\n",
     "# store = AzureStore.from_url(\n",
-    "#     \"https://overturemapswestus2.blob.core.windows.net/release/2025-06-25.0\",\n",
+    "#     f\"https://overturemapswestus2.blob.core.windows.net/{latest}\",\n",
     "#     skip_signature=True,\n",
     "# )"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "dcaf6e1c-e067-4a29-84b7-916fca8cf8d5",
+   "id": "14",
    "metadata": {},
    "source": [
     "Let's inspect the directories under this release. The [`list_with_delimiter`](https://developmentseed.org/obstore/latest/api/list/#obstore.list_with_delimiter) method shows us the `common_prefixes` (i.e. directories) underneath our top-level bucket prefix.\n"
@@ -149,7 +193,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4e61872e",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +202,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62cfd8a6-7842-4bf1-9fa9-85ff6151c4de",
+   "id": "16",
    "metadata": {},
    "source": [
     "Now let's say we want to visualize buildings; we can inspect the directories within `theme=buildings`:\n"
@@ -167,7 +211,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5570867c",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +220,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5d90dd0e-e632-48ac-b685-b4c2d7274a0d",
+   "id": "18",
    "metadata": {},
    "source": [
     "And the directories within `theme=buildings/type=building`.\n",
@@ -187,7 +231,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1fa90048",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,7 +241,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82e3c505-ca95-46fd-b430-c1d663a6f7f9",
+   "id": "20",
    "metadata": {},
    "source": [
     "## Creating a `GeoParquetDataset`\n"
@@ -205,7 +249,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ca9b07c4-d008-498c-8850-c280c3264350",
+   "id": "21",
    "metadata": {},
    "source": [
     "Now we can open a `GeoParquetDataset` with these objects:\n"
@@ -214,7 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3657e121-bd0d-4e2e-9420-079ab3d4cdee",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -223,7 +267,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e448efef-5f8d-4571-9185-11b34f3b9844",
+   "id": "23",
    "metadata": {},
    "source": [
     "We can see how many _row groups_, or partitions, exist in the dataset:\n"
@@ -232,7 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f5841504",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -241,7 +285,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "09455343-000d-4c7c-8ac2-14653a1c616c",
+   "id": "25",
    "metadata": {},
    "source": [
     "And the total number of rows:\n"
@@ -250,7 +294,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3c26197d",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -259,7 +303,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a61c8dab-5a6c-4301-9b55-8445681a3908",
+   "id": "27",
    "metadata": {},
    "source": [
     "Calling `dataset.fragments` gives us access the raw underlying GeoParquet files:\n"
@@ -268,7 +312,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9f64e0b0-5fb0-476e-9be2-bbbfb7b2887c",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -277,7 +321,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43a1bc08-8907-4602-a6f6-f3d43c459077",
+   "id": "29",
    "metadata": {},
    "source": [
     "## Visualizing file-based Spatial Partitioning\n",
@@ -292,7 +336,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "de2f0c87-07fe-417b-a38e-bd06896823a7",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -302,7 +346,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0fc6c029-92c9-40eb-8733-e2d010855013",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -315,7 +359,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cacf5c76-cf63-4393-83b4-65b2552768c6",
+   "id": "32",
    "metadata": {},
    "source": [
     "## Visualizing Row Group-based Spatial Partitioning\n"
@@ -323,7 +367,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6ab983a2-a7be-4790-8124-b2bfe065cb58",
+   "id": "33",
    "metadata": {},
    "source": [
     "> **_Note_**: I'm not sure why but Lonboard has been less stable for me recently on Mac with large data. You may want to remove the above map before proceeding (right click on the cell containing the map, then choose \"Clear Cell Output\").\n",
@@ -338,7 +382,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b94f33d9-cb9a-4f4a-9cd4-2d1ec80e2fa7",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -356,7 +400,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a742453d-1f20-4212-ac84-ae16ca3fada2",
+   "id": "35",
    "metadata": {},
    "source": [
     "So for example, the first GeoParquet file has these bounds for each GeoParquet row group:\n"
@@ -365,7 +409,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e5cd06b2-4d0c-43a1-9325-c17da4296f9d",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,7 +418,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fe197a41-5153-4b31-a44c-3d5ac519bee1",
+   "id": "37",
    "metadata": {},
    "source": [
     "Now we'll create a Lonboard `PolygonLayer` for each of these chunks. We'll use the following color mapping to give the chunks from each file a different color.\n"
@@ -383,7 +427,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80f3479f-f290-4ea9-89eb-ed58ed02071d",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -405,7 +449,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c6f3c52b-9cb7-4b8c-b7b4-080d9d0d39c1",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -426,7 +470,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70161397",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -436,7 +480,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f9b3e5aa-f3eb-44f3-b9a0-9cc8549f927c",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -445,7 +489,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24510d8e-00c2-41bf-827c-5efea07ac917",
+   "id": "42",
    "metadata": {},
    "source": [
     "## Fetching GeoParquet data\n"
@@ -453,7 +497,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a2362708-c41a-468b-b3d3-b5f77dd3192f",
+   "id": "43",
    "metadata": {},
    "source": [
     "Now we'll fetch a spatial subset of data.\n",
@@ -464,7 +508,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2133d64d",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -474,7 +518,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eb1fb5e1-3ab6-4ab4-b3de-f78dc8d2a13e",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -485,7 +529,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7db02e53-9fef-48b3-b2f7-7816b4ca6a4a",
+   "id": "46",
    "metadata": {},
    "source": [
     "Now we can use the `read` method on our `GeoParquetDataset` to actually fetch data.\n"
@@ -494,7 +538,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c8332d85-518f-4b07-85e7-fadc5d1686a6",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -504,7 +548,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f3f0c33a-4612-4d0b-b657-c88e3310dc86",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -513,7 +557,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1ce7571c-1b6d-4c2a-949f-fa3a912f54f9",
+   "id": "49",
    "metadata": {},
    "source": [
     "Now you should be able to plot the data directly!\n"
@@ -522,7 +566,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7299e3c9-0a48-470c-8a92-15f68751a088",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -532,7 +576,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3904c279-87aa-4f71-93b7-d8b7ec435ae6",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -540,7 +584,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -554,7 +598,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.14.0"
   }
  },
  "nbformat": 4,

--- a/examples/overture-geoparquet.ipynb
+++ b/examples/overture-geoparquet.ipynb
@@ -77,7 +77,6 @@
     "import shapely\n",
     "from arro3.core import Array, DataType, Table\n",
     "from geoarrow.rust.io import GeoParquetDataset\n",
-    "import obstore as obs\n",
     "from obstore.store import S3Store\n",
     "\n",
     "from lonboard import Map, PolygonLayer, viz\n",
@@ -97,7 +96,7 @@
    "id": "6",
    "metadata": {},
    "source": [
-    "Getting latest Overture data on AWS S3 by listing the releases in the bucket first and choosing one. \n"
+    "We'll create an [S3Store](https://developmentseed.org/obstore/latest/api/store/aws/#obstore.store.S3Store) to access Overture data on AWS S3.\n"
    ]
   },
   {
@@ -111,55 +110,12 @@
     "    \"s3://overturemaps-us-west-2\",\n",
     "    region=\"us-west-2\",\n",
     "    skip_signature=True,\n",
-    ")\n",
-    "\n",
-    "result = obs.list_with_delimiter(store, prefix=\"release\")\n",
-    "latest = sorted(result[\"common_prefixes\"])[-1]"
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "8",
-   "metadata": {},
-   "source": [
-    "Latest Overture release prefix:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "latest"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "10",
-   "metadata": {},
-   "source": [
-    "We'll create an [S3Store](https://developmentseed.org/obstore/latest/api/store/aws/#obstore.store.S3Store) to access Overture data on AWS S3.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "11",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "store = S3Store.from_url(                                                                                                                                                  \n",
-    "      f\"s3://overturemaps-us-west-2/{latest}/\",                                                                                                                              \n",
-    "      region=\"us-west-2\",                                                                                                                                                    \n",
-    "      skip_signature=True,                                                                                                                                                   \n",
-    "  )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "12",
    "metadata": {},
    "source": [
     "Overture has [two official copies](https://docs.overturemaps.org/getting-data/#official-overture-sources) of their distribution: one on AWS and another on Azure Storage.\n",
@@ -170,7 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -180,6 +136,43 @@
     "#     f\"https://overturemapswestus2.blob.core.windows.net/{latest}\",\n",
     "#     skip_signature=True,\n",
     "# )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10",
+   "metadata": {},
+   "source": [
+    "Getting latest Overture data on AWS S3 by listing the releases in the bucket first and choosing one. \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = store.list_with_delimiter(prefix=\"release\")\n",
+    "latest = sorted(result[\"common_prefixes\"])[-1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12",
+   "metadata": {},
+   "source": [
+    "Latest Overture release prefix:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "latest"
    ]
   },
   {
@@ -197,7 +190,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "store.list_with_delimiter()"
+    "store.list_with_delimiter(prefix=latest)"
    ]
   },
   {
@@ -215,7 +208,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "store.list_with_delimiter(\"theme=buildings\")"
+    "store.list_with_delimiter(f\"{latest}/theme=buildings\")"
    ]
   },
   {
@@ -235,7 +228,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "objects = store.list_with_delimiter(\"theme=buildings/type=building\")[\"objects\"]\n",
+    "objects = store.list_with_delimiter(f\"{latest}/theme=buildings/type=building\")[\"objects\"]\n",
     "objects[:2]"
    ]
   },

--- a/examples/overture-geoparquet.ipynb
+++ b/examples/overture-geoparquet.ipynb
@@ -77,7 +77,6 @@
     "import shapely\n",
     "from arro3.core import Array, DataType, Table\n",
     "from geoarrow.rust.io import GeoParquetDataset\n",
-    "from obstore.store import S3Store\n",
     "\n",
     "from lonboard import Map, PolygonLayer, viz\n",
     "from lonboard.basemap import CartoBasemap"
@@ -106,9 +105,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "store = S3Store.from_url(\n",
-    "    \"s3://overturemaps-us-west-2\",\n",
+    "from obstore.store import S3Store\n",
+    "\n",
+    "store = S3Store(\n",
+    "    bucket=\"overturemaps-us-west-2\",\n",
     "    region=\"us-west-2\",\n",
+    "    prefix=\"release\",\n",
     "    skip_signature=True,\n",
     ")"
    ]
@@ -130,12 +132,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# from obstore.store import AzureStore\n",
+    "from obstore.store import AzureStore\n",
     "\n",
-    "# store = AzureStore.from_url(\n",
-    "#     f\"https://overturemapswestus2.blob.core.windows.net/{latest}\",\n",
-    "#     skip_signature=True,\n",
-    "# )"
+    "store = AzureStore.from_url(\n",
+    "    \"https://overturemapswestus2.blob.core.windows.net/release\",\n",
+    "    skip_signature=True,\n",
+    ")"
    ]
   },
   {
@@ -143,17 +145,17 @@
    "id": "10",
    "metadata": {},
    "source": [
-    "Getting latest Overture data on AWS S3 by listing the releases in the bucket first and choosing one. \n"
+    "We can find the latest Overture data release on AWS S3 by listing the releases in the bucket first and choosing one:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "14dd4561-95b5-4bc7-a5ad-a9be458dcaa8",
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = store.list_with_delimiter(prefix=\"release\")\n",
+    "result = store.list_with_delimiter()\n",
     "latest = sorted(result[\"common_prefixes\"])[-1]"
    ]
   },
@@ -208,7 +210,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "store.list_with_delimiter(f\"{latest}/theme=buildings\")"
+    "store.list_with_delimiter(prefix=f\"{latest}/theme=buildings\")"
    ]
   },
   {
@@ -228,7 +230,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "objects = store.list_with_delimiter(f\"{latest}/theme=buildings/type=building\")[\"objects\"]\n",
+    "objects = store.list_with_delimiter(prefix=f\"{latest}/theme=buildings/type=building\")[\n",
+    "    \"objects\"\n",
+    "]\n",
     "objects[:2]"
    ]
   },
@@ -591,7 +595,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.14.0"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/examples/overture-geoparquet.ipynb
+++ b/examples/overture-geoparquet.ipynb
@@ -132,12 +132,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from obstore.store import AzureStore\n",
+    "# from obstore.store import AzureStore\n",
     "\n",
-    "store = AzureStore.from_url(\n",
-    "    \"https://overturemapswestus2.blob.core.windows.net/release\",\n",
-    "    skip_signature=True,\n",
-    ")"
+    "# store = AzureStore.from_url(\n",
+    "#     \"https://overturemapswestus2.blob.core.windows.net/release\",\n",
+    "#     skip_signature=True,\n",
+    "# )"
    ]
   },
   {


### PR DESCRIPTION
making the release version dynamic by listing the S3 bucket with obstore.list_with_delimiter instead of hardcoding a release date

Closes #1027