### PR TITLE
fix: Add morecantile as dependency in COG jupyter notebooks

### DIFF
--- a/examples/raster-cog-nlcd-server.ipynb
+++ b/examples/raster-cog-nlcd-server.ipynb
@@ -16,6 +16,7 @@
     "# dependencies = [\n",
     "#     \"async-geotiff>=0.4\",\n",
     "#     \"lonboard>=0.15.0\",\n",
+    "#     \"morecantile>=7.0.3\",\n",
     "#     \"numpy>=2\",\n",
     "#     \"obstore>=0.9.2\",\n",
     "#     \"pillow>=12.1.1\",\n",


### PR DESCRIPTION
Closes #1169 