### PR TITLE
chore: bump to deck.gl-geoarrow package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
           - "*loaders*"
           - "*luma*"
         exclude-patterns:
-          - "@geoarrow/deck.gl-layers"
+          - "@geoarrow/deck.gl-geoarrow"
       other:
         patterns:
           - "*"

--- a/docs/how-it-works/index.md
+++ b/docs/how-it-works/index.md
@@ -16,7 +16,7 @@ Lonboard is so fast because it moves data from Python to JavaScript (in your bro
 
 Other Python libraries for interactive maps exist (such as [`ipyleaflet`](https://github.com/jupyter-widgets/ipyleaflet)), and even existing bindings to deck.gl exist (such as [`pydeck`](https://pypi.org/project/pydeck/)). But those libraries encode data as GeoJSON to copy from Python to the browser. GeoJSON is **extremely slow** to read and write and results in a very large data file that has to be copied to the browser.
 
-With lonboard, the _entire pipeline_ is binary. In Python, GeoPandas to GeoArrow to GeoParquet avoids a text encoding like GeoJSON and results in a compressed binary buffer that can be efficiently copied to the browser. In JavaScript, GeoParquet to GeoArrow offers efficient decoding ([in WebAssembly](https://github.com/kylebarron/parquet-wasm/)). Then deck.gl is able to interpret the GeoArrow table _directly_ without any parsing (thanks to [`@geoarrow/deck.gl-layers`](https://github.com/geoarrow/deck.gl-layers)).
+With lonboard, the _entire pipeline_ is binary. In Python, GeoPandas to GeoArrow to GeoParquet avoids a text encoding like GeoJSON and results in a compressed binary buffer that can be efficiently copied to the browser. In JavaScript, GeoParquet to GeoArrow offers efficient decoding ([in WebAssembly](https://github.com/kylebarron/parquet-wasm/)). Then deck.gl is able to interpret the GeoArrow table _directly_ without any parsing (thanks to [`@geoarrow/deck.gl-geoarrow`](https://github.com/geoarrow/deck.gl-geoarrow)).
 
 [GeoPandas](https://geopandas.org/en/stable/) is the primary interface for users to add data, allowing lonboard to internally manage the conversion to GeoArrow and its transport to the browser for rendering.
 

--- a/docs/how-it-works/internals.md
+++ b/docs/how-it-works/internals.md
@@ -33,7 +33,7 @@ This experience informs the target user of Lonboard:
 
 The `Map` class is the primary and only widget associated with JavaScript that renders anything. `Map` subclasses from `anywidget.AnyWidget`, which dynamically fetches Lonboard's JavaScript ESM bundle. The `Map` class emulates deck.gl's `Deck` class. It synchronizes map state and can be passed a sequence of `Layer` objects.
 
-`Layer` classes are designed to map to each underlying deck.gl layer. Most `Layer` classes subclass from `BaseArrowLayer`, which stores a `pyarrow.Table` in the dataclass. This data object gets serialized to Parquet and rendered in a layer provided by `@geoarrow/deck.gl-layers` as described later on. The primary API for each of these Arrow-based layers is `from_geopandas`, which converts a `GeoDataFrame` to a `pyarrow.Table` with a [GeoArrow](https://geoarrow.org/)-represented geometry column. A few layers are not Arrow-based and do not subclass from `BaseArrowLayer`: primarily `BitmapLayer` and `BitmapTileLayer`. These pass user data input directly into a core deck.gl layer.
+`Layer` classes are designed to map to each underlying deck.gl layer. Most `Layer` classes subclass from `BaseArrowLayer`, which stores a `pyarrow.Table` in the dataclass. This data object gets serialized to Parquet and rendered in a layer provided by `@geoarrow/deck.gl-geoarrow` as described later on. The primary API for each of these Arrow-based layers is `from_geopandas`, which converts a `GeoDataFrame` to a `pyarrow.Table` with a [GeoArrow](https://geoarrow.org/)-represented geometry column. A few layers are not Arrow-based and do not subclass from `BaseArrowLayer`: primarily `BitmapLayer` and `BitmapTileLayer`. These pass user data input directly into a core deck.gl layer.
 
 These `Layer` classes subclass from `ipywidgets.Widget` but are _not_ associated with any JavaScript of their own. But by being widgets themselves, their data is synced with JavaScript and Python data changes are propagated as events to the core `Map` object.
 
@@ -73,7 +73,7 @@ In contrast, having the JavaScript side load data directly from a URL requires s
 
 ### Layer Creation
 
-With the exception of the `BitmapLayer`, no _direct_ deck.gl layers are used. deck.gl layers are used _exclusively_ through the [`@geoarrow/deck.gl-layers`](https://github.com/geoarrow/deck.gl-layers) glue library. This library connects GeoArrow data to the low-level binary data API of each deck.gl layer. **All** accessors are passed in directly as binary buffers.
+With the exception of the `BitmapLayer`, no _direct_ deck.gl layers are used. deck.gl layers are used _exclusively_ through the [`@geoarrow/deck.gl-geoarrow`](https://github.com/geoarrow/deck.gl-geoarrow) glue library. This library connects GeoArrow data to the low-level binary data API of each deck.gl layer. **All** accessors are passed in directly as binary buffers.
 
 This means that in JavaScript the data _never_ leaves an Arrow binary representation. It's parsed from Parquet to Arrow in WebAssembly, the Arrow buffers are copied out of WebAssembly memory, but never parsed to JSON strings or JavaScript objects.
 

--- a/lonboard/layer/__init__.py
+++ b/lonboard/layer/__init__.py
@@ -5,7 +5,7 @@
 #   serialized to JS as `null` and will not be passed into the GeoArrow model (see the
 #   lengthy assignments of type `..(isDefined(this.param) && { param: this.param })`).
 #   Then the default value in the JS GeoArrow layer (defined in
-#   `@geoarrow/deck.gl-layers`) will be used.
+#   `@geoarrow/deck.gl-geoarrow`) will be used.
 
 from ._a5 import A5Layer
 from ._arc import ArcLayer

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@developmentseed/deck.gl-raster": "^0.6.1",
     "@developmentseed/morecantile": "^0.6.1",
     "@developmentseed/raster-reproject": "^0.6.1",
-    "@geoarrow/deck.gl-layers": "^0.4.0-beta.6",
+    "@geoarrow/deck.gl-geoarrow": "^0.4.0",
     "@geoarrow/geoarrow-js": "^0.3.2",
     "@maplibre/maplibre-gl-geocoder": "^1.9.4",
     "@nextui-org/react": "^2.4.8",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@developmentseed/deck.gl-raster": "^0.6.1",
     "@developmentseed/morecantile": "^0.6.1",
     "@developmentseed/raster-reproject": "^0.6.1",
-    "@geoarrow/deck.gl-geoarrow": "^0.4.0",
+    "@geoarrow/deck.gl-geoarrow": "^0.4.1",
     "@geoarrow/geoarrow-js": "^0.3.2",
     "@maplibre/maplibre-gl-geocoder": "^1.9.4",
     "@nextui-org/react": "^2.4.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,9 +62,9 @@ importers:
       '@developmentseed/raster-reproject':
         specifier: ^0.6.1
         version: 0.6.1
-      '@geoarrow/deck.gl-layers':
-        specifier: ^0.4.0-beta.6
-        version: 0.4.0-beta.6(a9eb2aa8016678001e60d52f9322d46c)
+      '@geoarrow/deck.gl-geoarrow':
+        specifier: ^0.4.0
+        version: 0.4.0(a9eb2aa8016678001e60d52f9322d46c)
       '@geoarrow/geoarrow-js':
         specifier: ^0.3.2
         version: 0.3.3(apache-arrow@21.1.0)
@@ -843,9 +843,8 @@ packages:
   '@formatjs/intl-localematcher@0.6.2':
     resolution: {integrity: sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==}
 
-  '@geoarrow/deck.gl-layers@0.4.0-beta.6':
-    resolution: {integrity: sha512-figzvJOeH2zND7lnvCBZkSk+PvfNpyKTRmLqNdbT55Ju+hjf4CWorDbpSeQNYUnPKm+iAidx2yFFABHXzii7uA==}
-    deprecated: This package has been renamed to @geoarrow/deck.gl-geoarrow
+  '@geoarrow/deck.gl-geoarrow@0.4.0':
+    resolution: {integrity: sha512-yYDEiIfs2WcRWwWCvIhUe2Cxtv/MkBHs8nN+H0osOMrjp9wZG4Eah5OQuFmzfxZcRnH5DrJlNicYK77lmtHbtA==}
     peerDependencies:
       '@deck.gl/aggregation-layers': ^9.3.1
       '@deck.gl/core': ^9.3.1
@@ -5037,7 +5036,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@geoarrow/deck.gl-layers@0.4.0-beta.6(a9eb2aa8016678001e60d52f9322d46c)':
+  '@geoarrow/deck.gl-geoarrow@0.4.0(a9eb2aa8016678001e60d52f9322d46c)':
     dependencies:
       '@deck.gl/aggregation-layers': 9.3.1(@deck.gl/core@9.3.2)(@deck.gl/layers@9.3.2(@deck.gl/core@9.3.2)(@loaders.gl/core@4.4.1)(@luma.gl/core@9.3.3)(@luma.gl/engine@9.3.3(@luma.gl/core@9.3.3)(@luma.gl/shadertools@9.3.3(@luma.gl/core@9.3.3))))(@luma.gl/core@9.3.3)(@luma.gl/engine@9.3.3(@luma.gl/core@9.3.3)(@luma.gl/shadertools@9.3.3(@luma.gl/core@9.3.3)))
       '@deck.gl/core': 9.3.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: ^0.6.1
         version: 0.6.1
       '@geoarrow/deck.gl-geoarrow':
-        specifier: ^0.4.0
-        version: 0.4.0(a9eb2aa8016678001e60d52f9322d46c)
+        specifier: ^0.4.1
+        version: 0.4.1(a9eb2aa8016678001e60d52f9322d46c)
       '@geoarrow/geoarrow-js':
         specifier: ^0.3.2
         version: 0.3.3(apache-arrow@21.1.0)
@@ -843,8 +843,8 @@ packages:
   '@formatjs/intl-localematcher@0.6.2':
     resolution: {integrity: sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==}
 
-  '@geoarrow/deck.gl-geoarrow@0.4.0':
-    resolution: {integrity: sha512-yYDEiIfs2WcRWwWCvIhUe2Cxtv/MkBHs8nN+H0osOMrjp9wZG4Eah5OQuFmzfxZcRnH5DrJlNicYK77lmtHbtA==}
+  '@geoarrow/deck.gl-geoarrow@0.4.1':
+    resolution: {integrity: sha512-WYRuN1UnDkudOivyXwa6vPRCfiZmfax2NvQf99vbGyrN1EiY+UzuB2XHdZvEGUScUg2xo30iei91CvwTetH6AA==}
     peerDependencies:
       '@deck.gl/aggregation-layers': ^9.3.1
       '@deck.gl/core': ^9.3.1
@@ -5036,7 +5036,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@geoarrow/deck.gl-geoarrow@0.4.0(a9eb2aa8016678001e60d52f9322d46c)':
+  '@geoarrow/deck.gl-geoarrow@0.4.1(a9eb2aa8016678001e60d52f9322d46c)':
     dependencies:
       '@deck.gl/aggregation-layers': 9.3.1(@deck.gl/core@9.3.2)(@deck.gl/layers@9.3.2(@deck.gl/core@9.3.2)(@loaders.gl/core@4.4.1)(@luma.gl/core@9.3.3)(@luma.gl/engine@9.3.3(@luma.gl/core@9.3.3)(@luma.gl/shadertools@9.3.3(@luma.gl/core@9.3.3))))(@luma.gl/core@9.3.3)(@luma.gl/engine@9.3.3(@luma.gl/core@9.3.3)(@luma.gl/shadertools@9.3.3(@luma.gl/core@9.3.3)))
       '@deck.gl/core': 9.3.2

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,7 @@ import type { MapViewState, PickingInfo } from "@deck.gl/core";
 import type { PolygonLayerProps } from "@deck.gl/layers";
 import { PolygonLayer } from "@deck.gl/layers";
 import type { DeckGLRef } from "@deck.gl/react";
-import type { GeoArrowPickingInfo } from "@geoarrow/deck.gl-layers";
+import type { GeoArrowPickingInfo } from "@geoarrow/deck.gl-geoarrow";
 import type { IWidgetManager } from "@jupyter-widgets/base";
 import { NextUIProvider } from "@nextui-org/react";
 import debounce from "lodash.debounce";

--- a/src/model/earcut-pool.ts
+++ b/src/model/earcut-pool.ts
@@ -16,13 +16,13 @@ function createEarcutPool(earcutWorkerPoolSize: number): Pool<FunctionThread> {
 /**
  * The PolygonLayer and SolidPolygonLayer perform [Earcut][earcut] triangulation on worker threads.
  *
- * Previously, in deck.gl-layers v0.3, there was an earcut worker pool created
+ * Previously, in deck.gl-geoarrow v0.3, there was an earcut worker pool created
  * internally per GeoArrowPolygonLayer or GeoArrowSolidPolygonLayer. This wasn't
  * ideal, because if you had multiple polygon layers, you'd end up with multiple
  * earcut worker pools competing for resources. But it wasn't _that_ bad because
  * each GeoArrow layer rendered all batches within a table.
  *
- * In the deck.gl-layers upgrade to v0.4, there's now only deck.gl layer call per _record batch_, not per _table_. That means by default we'd be creating a new earcut worker pool for **every record batch**.
+ * In the deck.gl-geoarrow upgrade to v0.4, there's now only deck.gl layer call per _record batch_, not per _table_. That means by default we'd be creating a new earcut worker pool for **every record batch**.
  *
  * Instead, we now create a single top-level earcut worker pool that is shared across all GeoArrow polygon layers.
  *

--- a/src/model/layer/arc.ts
+++ b/src/model/layer/arc.ts
@@ -1,5 +1,5 @@
-import type { GeoArrowArcLayerProps } from "@geoarrow/deck.gl-layers";
-import { GeoArrowArcLayer } from "@geoarrow/deck.gl-layers";
+import type { GeoArrowArcLayerProps } from "@geoarrow/deck.gl-geoarrow";
+import { GeoArrowArcLayer } from "@geoarrow/deck.gl-geoarrow";
 import type { WidgetModel } from "@jupyter-widgets/base";
 import { isDefined } from "../../util.js";
 import type {

--- a/src/model/layer/column.ts
+++ b/src/model/layer/column.ts
@@ -1,5 +1,5 @@
-import type { GeoArrowColumnLayerProps } from "@geoarrow/deck.gl-layers";
-import { GeoArrowColumnLayer } from "@geoarrow/deck.gl-layers";
+import type { GeoArrowColumnLayerProps } from "@geoarrow/deck.gl-geoarrow";
+import { GeoArrowColumnLayer } from "@geoarrow/deck.gl-geoarrow";
 import type { WidgetModel } from "@jupyter-widgets/base";
 import { isDefined } from "../../util.js";
 import type {

--- a/src/model/layer/heatmap.ts
+++ b/src/model/layer/heatmap.ts
@@ -1,5 +1,5 @@
-import type { GeoArrowHeatmapLayerProps } from "@geoarrow/deck.gl-layers";
-import { GeoArrowHeatmapLayer } from "@geoarrow/deck.gl-layers";
+import type { GeoArrowHeatmapLayerProps } from "@geoarrow/deck.gl-geoarrow";
+import { GeoArrowHeatmapLayer } from "@geoarrow/deck.gl-geoarrow";
 import type { WidgetModel } from "@jupyter-widgets/base";
 
 import { isDefined } from "../../util.js";

--- a/src/model/layer/path.ts
+++ b/src/model/layer/path.ts
@@ -1,5 +1,5 @@
-import type { GeoArrowPathLayerProps } from "@geoarrow/deck.gl-layers";
-import { GeoArrowPathLayer } from "@geoarrow/deck.gl-layers";
+import type { GeoArrowPathLayerProps } from "@geoarrow/deck.gl-geoarrow";
+import { GeoArrowPathLayer } from "@geoarrow/deck.gl-geoarrow";
 import type { WidgetModel } from "@jupyter-widgets/base";
 
 import { isDefined } from "../../util.js";

--- a/src/model/layer/point-cloud.ts
+++ b/src/model/layer/point-cloud.ts
@@ -1,5 +1,5 @@
-import type { GeoArrowPointCloudLayerProps } from "@geoarrow/deck.gl-layers";
-import { GeoArrowPointCloudLayer } from "@geoarrow/deck.gl-layers";
+import type { GeoArrowPointCloudLayerProps } from "@geoarrow/deck.gl-geoarrow";
+import { GeoArrowPointCloudLayer } from "@geoarrow/deck.gl-geoarrow";
 import type { WidgetModel } from "@jupyter-widgets/base";
 
 import { isDefined } from "../../util.js";

--- a/src/model/layer/polygon.ts
+++ b/src/model/layer/polygon.ts
@@ -5,7 +5,7 @@ import type {
   GeoArrowPolygonLayerProps,
   GeoArrowS2LayerProps,
   GeoArrowSolidPolygonLayerProps,
-} from "@geoarrow/deck.gl-layers";
+} from "@geoarrow/deck.gl-geoarrow";
 import {
   GeoArrowA5Layer,
   GeoArrowGeohashLayer,
@@ -13,7 +13,7 @@ import {
   GeoArrowPolygonLayer,
   GeoArrowS2Layer,
   GeoArrowSolidPolygonLayer,
-} from "@geoarrow/deck.gl-layers";
+} from "@geoarrow/deck.gl-geoarrow";
 import type { WidgetModel } from "@jupyter-widgets/base";
 import type * as arrow from "apache-arrow";
 

--- a/src/model/layer/scatterplot.ts
+++ b/src/model/layer/scatterplot.ts
@@ -1,5 +1,5 @@
-import type { GeoArrowScatterplotLayerProps } from "@geoarrow/deck.gl-layers";
-import { GeoArrowScatterplotLayer } from "@geoarrow/deck.gl-layers";
+import type { GeoArrowScatterplotLayerProps } from "@geoarrow/deck.gl-geoarrow";
+import { GeoArrowScatterplotLayer } from "@geoarrow/deck.gl-geoarrow";
 import type { WidgetModel } from "@jupyter-widgets/base";
 
 import { isDefined } from "../../util.js";

--- a/src/model/layer/text.ts
+++ b/src/model/layer/text.ts
@@ -1,5 +1,5 @@
-import type { _GeoArrowTextLayerProps as GeoArrowTextLayerProps } from "@geoarrow/deck.gl-layers";
-import { _GeoArrowTextLayer as GeoArrowTextLayer } from "@geoarrow/deck.gl-layers";
+import type { _GeoArrowTextLayerProps as GeoArrowTextLayerProps } from "@geoarrow/deck.gl-geoarrow";
+import { _GeoArrowTextLayer as GeoArrowTextLayer } from "@geoarrow/deck.gl-geoarrow";
 import type { WidgetModel } from "@jupyter-widgets/base";
 
 import { isDefined } from "../../util.js";

--- a/src/model/layer/trips.ts
+++ b/src/model/layer/trips.ts
@@ -1,5 +1,5 @@
-import type { GeoArrowTripsLayerProps } from "@geoarrow/deck.gl-layers";
-import { GeoArrowTripsLayer } from "@geoarrow/deck.gl-layers";
+import type { GeoArrowTripsLayerProps } from "@geoarrow/deck.gl-geoarrow";
+import { GeoArrowTripsLayer } from "@geoarrow/deck.gl-geoarrow";
 import type { WidgetModel } from "@jupyter-widgets/base";
 
 import { isDefined } from "../../util.js";

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -1,7 +1,7 @@
 import type {
   ColorAccessor,
   FloatAccessor,
-} from "@geoarrow/deck.gl-layers/src/types";
+} from "@geoarrow/deck.gl-geoarrow/src/types";
 import type * as ga from "@geoarrow/geoarrow-js";
 import type {
   FixedSizeList,

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -1,7 +1,4 @@
-import type {
-  ColorAccessor,
-  FloatAccessor,
-} from "@geoarrow/deck.gl-geoarrow/src/types";
+import type { ColorAccessor, FloatAccessor } from "@geoarrow/deck.gl-geoarrow";
 import type * as ga from "@geoarrow/geoarrow-js";
 import type {
   FixedSizeList,

--- a/src/sidepanel/index.tsx
+++ b/src/sidepanel/index.tsx
@@ -1,4 +1,4 @@
-import type { GeoArrowPickingInfo } from "@geoarrow/deck.gl-layers";
+import type { GeoArrowPickingInfo } from "@geoarrow/deck.gl-geoarrow";
 import { Button } from "@nextui-org/react";
 import React from "react";
 

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -4,7 +4,7 @@
  * Manages ephemeral UI state that never syncs with Python. For Python-synced state,
  * use Backbone models via `useViewStateDebounced()` from `./python-sync.ts`.
  */
-import type { GeoArrowPickingInfo } from "@geoarrow/deck.gl-layers";
+import type { GeoArrowPickingInfo } from "@geoarrow/deck.gl-geoarrow";
 import { create } from "zustand";
 
 /** Shape of the client-side UI state. All properties are UI-only. */

--- a/src/tooltip/index.ts
+++ b/src/tooltip/index.ts
@@ -1,5 +1,5 @@
 import type { TooltipContent } from "@deck.gl/core/dist/lib/tooltip";
-import type { GeoArrowPickingInfo } from "@geoarrow/deck.gl-layers";
+import type { GeoArrowPickingInfo } from "@geoarrow/deck.gl-geoarrow";
 
 import "./index.css";
 


### PR DESCRIPTION
Update to deck.gl-geoarrow v0.4

Looks like CI is currently failing due to https://github.com/geopandas/geodatasets/issues/35