### PR TITLE
docs: Turn off layer attribute labels in docs

### DIFF
--- a/docs/api/basemap.md
+++ b/docs/api/basemap.md
@@ -1,4 +1,11 @@
 # lonboard.basemap
 
 ::: lonboard.basemap.MaplibreBasemap
+    options:
+      inherited_members: true
+      show_labels: false
+
 ::: lonboard.basemap.CartoStyle
+    options:
+      inherited_members: true
+      show_labels: false

--- a/docs/api/layers/a5-layer.md
+++ b/docs/api/layers/a5-layer.md
@@ -3,3 +3,4 @@
 ::: lonboard.A5Layer
     options:
       inherited_members: true
+      show_labels: false

--- a/docs/api/layers/arc-layer.md
+++ b/docs/api/layers/arc-layer.md
@@ -7,3 +7,4 @@
 ::: lonboard.ArcLayer
     options:
       inherited_members: true
+      show_labels: false

--- a/docs/api/layers/base-layer.md
+++ b/docs/api/layers/base-layer.md
@@ -3,7 +3,9 @@
 ::: lonboard.BaseLayer
     options:
       inherited_members: true
+      show_labels: false
 
 ::: lonboard.BaseArrowLayer
     options:
       inherited_members: true
+      show_labels: false

--- a/docs/api/layers/bitmap-layer.md
+++ b/docs/api/layers/bitmap-layer.md
@@ -3,3 +3,4 @@
 ::: lonboard.BitmapLayer
     options:
       inherited_members: true
+      show_labels: false

--- a/docs/api/layers/bitmap-tile-layer.md
+++ b/docs/api/layers/bitmap-tile-layer.md
@@ -3,3 +3,4 @@
 ::: lonboard.BitmapTileLayer
     options:
       inherited_members: true
+      show_labels: false

--- a/docs/api/layers/column-layer.md
+++ b/docs/api/layers/column-layer.md
@@ -3,3 +3,4 @@
 ::: lonboard.ColumnLayer
     options:
       inherited_members: true
+      show_labels: false

--- a/docs/api/layers/geohash-layer.md
+++ b/docs/api/layers/geohash-layer.md
@@ -3,3 +3,4 @@
 ::: lonboard.GeohashLayer
     options:
       inherited_members: true
+      show_labels: false

--- a/docs/api/layers/h3-hexagon-layer.md
+++ b/docs/api/layers/h3-hexagon-layer.md
@@ -7,3 +7,4 @@
 ::: lonboard.H3HexagonLayer
     options:
       inherited_members: true
+      show_labels: false

--- a/docs/api/layers/heatmap-layer.md
+++ b/docs/api/layers/heatmap-layer.md
@@ -7,3 +7,4 @@
 ::: lonboard.HeatmapLayer
     options:
       inherited_members: true
+      show_labels: false

--- a/docs/api/layers/path-layer.md
+++ b/docs/api/layers/path-layer.md
@@ -7,3 +7,4 @@
 ::: lonboard.PathLayer
     options:
       inherited_members: true
+      show_labels: false

--- a/docs/api/layers/point-cloud-layer.md
+++ b/docs/api/layers/point-cloud-layer.md
@@ -3,3 +3,4 @@
 ::: lonboard.PointCloudLayer
     options:
       inherited_members: true
+      show_labels: false

--- a/docs/api/layers/polygon-layer.md
+++ b/docs/api/layers/polygon-layer.md
@@ -7,3 +7,4 @@
 ::: lonboard.PolygonLayer
     options:
       inherited_members: true
+      show_labels: false

--- a/docs/api/layers/raster-layer.md
+++ b/docs/api/layers/raster-layer.md
@@ -1,3 +1,6 @@
 # RasterLayer
 
 ::: lonboard.RasterLayer
+    options:
+      inherited_members: true
+      show_labels: false

--- a/docs/api/layers/s2-layer.md
+++ b/docs/api/layers/s2-layer.md
@@ -3,3 +3,4 @@
 ::: lonboard.S2Layer
     options:
       inherited_members: true
+      show_labels: false

--- a/docs/api/layers/scatterplot-layer.md
+++ b/docs/api/layers/scatterplot-layer.md
@@ -7,3 +7,4 @@
 ::: lonboard.ScatterplotLayer
     options:
       inherited_members: true
+      show_labels: false

--- a/docs/api/layers/solid-polygon-layer.md
+++ b/docs/api/layers/solid-polygon-layer.md
@@ -3,3 +3,4 @@
 ::: lonboard.SolidPolygonLayer
     options:
       inherited_members: true
+      show_labels: false

--- a/docs/api/layers/text-layer.md
+++ b/docs/api/layers/text-layer.md
@@ -3,3 +3,4 @@
 ::: lonboard.experimental.TextLayer
     options:
       inherited_members: true
+      show_labels: false

--- a/docs/api/layers/trips-layer.md
+++ b/docs/api/layers/trips-layer.md
@@ -11,3 +11,4 @@
         - "!from_duckdb"
         - "!from_geopandas"
       inherited_members: true
+      show_labels: false

--- a/docs/api/map.md
+++ b/docs/api/map.md
@@ -8,6 +8,7 @@ https://mkdocstrings.github.io/python/usage/configuration/members/#filters
       group_by_category: false
       show_bases: false
       filters:
+      show_labels: false
 
 ::: lonboard.types.map.MapKwargs
     options:


### PR DESCRIPTION
I always thought these labels were confusing and overly verbose, and just learned I can turn them off. Users shouldn't need to know what a "class attribute" or "instance attribute" is.

Before:

<img width="562" height="446" alt="image" src="https://github.com/user-attachments/assets/4362a9c0-869c-4fa0-b308-e61397c5d82c" />


After:

<img width="440" height="415" alt="image" src="https://github.com/user-attachments/assets/6d73df1b-2cc7-4c0c-9dd7-24823525656d" />
