### PR TITLE
fix: Support CRS-parameterized GEOMETRY type in DuckDB 1.5

### DIFF
--- a/lonboard/_geoarrow/_duckdb.py
+++ b/lonboard/_geoarrow/_duckdb.py
@@ -35,13 +35,13 @@ def _base_type_name(duckdb_type: duckdb.typing.DuckDBPyType) -> str:
     """Return the name of a DuckDB type without any type parameters.
 
     As of DuckDB 1.5, the spatial extension's GEOMETRY type is parameterized
-    with a CRS, e.g. ``GEOMETRY('EPSG:4326')``, so an exact string comparison
-    against ``"GEOMETRY"`` no longer matches.
+    with a CRS, e.g. `GEOMETRY('EPSG:4326')`, so an exact string comparison
+    against `"GEOMETRY"` no longer matches.
 
-    String parsing is the only way to do this: ``DuckDBPyType`` exposes only
-    ``id`` and ``children``, where ``id`` omits the type parameters (and is
-    ``'blob'`` for both GEOMETRY and WKB_BLOB on DuckDB 1.4, so it can't be
-    used for detection either) and ``children`` raises for non-nested types.
+    String parsing is the only way to do this: `DuckDBPyType` exposes only
+    `id` and `children`, where `id` omits the type parameters (and is
+    `'blob'` for both GEOMETRY and WKB_BLOB on DuckDB 1.4, so it can't be
+    used for detection either) and `children` raises for non-nested types.
     """
     return str(duckdb_type).split("(", 1)[0]
 

--- a/lonboard/_geoarrow/_duckdb.py
+++ b/lonboard/_geoarrow/_duckdb.py
@@ -31,13 +31,23 @@ DUCKDB_SPATIAL_TYPES = {
 }
 
 
+def _base_type_name(duckdb_type: duckdb.typing.DuckDBPyType) -> str:
+    """Return the name of a DuckDB type without any type parameters.
+
+    As of DuckDB 1.5, the spatial extension's GEOMETRY type is parameterized
+    with a CRS, e.g. ``GEOMETRY('EPSG:4326')``, so an exact string comparison
+    against ``"GEOMETRY"`` no longer matches.
+    """
+    return str(duckdb_type).split("(", 1)[0]
+
+
 def from_duckdb(
     rel: duckdb.DuckDBPyRelation,
     *,
     crs: str | pyproj.CRS | None = None,
 ) -> Table:
     geom_col_idxs = [
-        i for i, t in enumerate(rel.types) if str(t) in DUCKDB_SPATIAL_TYPES
+        i for i, t in enumerate(rel.types) if _base_type_name(t) in DUCKDB_SPATIAL_TYPES
     ]
 
     if len(geom_col_idxs) == 0:
@@ -54,7 +64,7 @@ def from_duckdb(
         raise ValueError(msg)
 
     geom_col_idx = geom_col_idxs[0]
-    geom_type = rel.types[geom_col_idx]
+    geom_type = _base_type_name(rel.types[geom_col_idx])
     if geom_type == "WKB_BLOB":
         return _from_geoarrow(
             rel,

--- a/lonboard/_geoarrow/_duckdb.py
+++ b/lonboard/_geoarrow/_duckdb.py
@@ -37,6 +37,11 @@ def _base_type_name(duckdb_type: duckdb.typing.DuckDBPyType) -> str:
     As of DuckDB 1.5, the spatial extension's GEOMETRY type is parameterized
     with a CRS, e.g. ``GEOMETRY('EPSG:4326')``, so an exact string comparison
     against ``"GEOMETRY"`` no longer matches.
+
+    String parsing is the only way to do this: ``DuckDBPyType`` exposes only
+    ``id`` and ``children``, where ``id`` omits the type parameters (and is
+    ``'blob'`` for both GEOMETRY and WKB_BLOB on DuckDB 1.4, so it can't be
+    used for detection either) and ``children`` raises for non-nested types.
     """
     return str(duckdb_type).split("(", 1)[0]
 

--- a/tests/test_duckdb.py
+++ b/tests/test_duckdb.py
@@ -28,7 +28,8 @@ def test_viz_geometry_default_con():
         SELECT * FROM ST_Read("{cities_gdal_path}");
         """
     rel = duckdb.sql(sql)
-    assert rel.types[-1] == "GEOMETRY"
+    # DuckDB 1.5+ parameterizes GEOMETRY with a CRS, e.g. GEOMETRY('EPSG:4326')
+    assert str(rel.types[-1]).startswith("GEOMETRY")
 
     m = viz(rel)
     assert isinstance(m.layers[0], ScatterplotLayer)
@@ -45,7 +46,8 @@ def test_viz_geometry():
         SELECT * FROM ST_Read("{cities_gdal_path}");
         """
     rel = con.sql(sql)
-    assert rel.types[-1] == "GEOMETRY"
+    # DuckDB 1.5+ parameterizes GEOMETRY with a CRS, e.g. GEOMETRY('EPSG:4326')
+    assert str(rel.types[-1]).startswith("GEOMETRY")
     m = viz(rel)
     assert isinstance(m.layers[0], ScatterplotLayer)
 
@@ -58,7 +60,8 @@ def test_viz_wkb_blob():
     sql = f"""
         INSTALL spatial;
         LOAD spatial;
-        SELECT name, ST_AsWKB(geom) as geom FROM ST_Read("{cities_gdal_path}");
+        -- Cast because ST_AsWKB returns plain BLOB (not WKB_BLOB) in DuckDB 1.5+
+        SELECT name, ST_AsWKB(geom)::WKB_BLOB as geom FROM ST_Read("{cities_gdal_path}");
         """
     rel = con.sql(sql)
     assert rel.types[-1] == "WKB_BLOB"
@@ -71,7 +74,9 @@ def test_viz_point_2d():
     sql = f"""
         INSTALL spatial;
         LOAD spatial;
-        SELECT name, CAST(geom as POINT_2D) as geom FROM ST_Read("{cities_gdal_path}");
+        -- Cast via plain GEOMETRY: DuckDB 1.5+ can't cast its
+        -- CRS-parameterized GEOMETRY directly to POINT_2D
+        SELECT name, CAST(geom::GEOMETRY as POINT_2D) as geom FROM ST_Read("{cities_gdal_path}");
         """
     rel = con.sql(sql)
     assert rel.types[-1] == "POINT_2D"
@@ -112,7 +117,8 @@ def test_layer_geometry():
         SELECT * FROM ST_Read("{cities_gdal_path}");
         """
     rel = con.sql(sql)
-    assert rel.types[-1] == "GEOMETRY"
+    # DuckDB 1.5+ parameterizes GEOMETRY with a CRS, e.g. GEOMETRY('EPSG:4326')
+    assert str(rel.types[-1]).startswith("GEOMETRY")
     layer = ScatterplotLayer.from_duckdb(rel, con=con)
     assert isinstance(layer, ScatterplotLayer)
 
@@ -125,7 +131,8 @@ def test_layer_wkb_blob():
     sql = f"""
         INSTALL spatial;
         LOAD spatial;
-        SELECT name, ST_AsWKB(geom) as geom FROM ST_Read("{cities_gdal_path}");
+        -- Cast because ST_AsWKB returns plain BLOB (not WKB_BLOB) in DuckDB 1.5+
+        SELECT name, ST_AsWKB(geom)::WKB_BLOB as geom FROM ST_Read("{cities_gdal_path}");
         """
     rel = con.sql(sql)
     assert rel.types[-1] == "WKB_BLOB"
@@ -138,7 +145,9 @@ def test_layer_point_2d():
     sql = f"""
         INSTALL spatial;
         LOAD spatial;
-        SELECT name, CAST(geom as POINT_2D) as geom FROM ST_Read("{cities_gdal_path}");
+        -- Cast via plain GEOMETRY: DuckDB 1.5+ can't cast its
+        -- CRS-parameterized GEOMETRY directly to POINT_2D
+        SELECT name, CAST(geom::GEOMETRY as POINT_2D) as geom FROM ST_Read("{cities_gdal_path}");
         """
     rel = con.sql(sql)
     assert rel.types[-1] == "POINT_2D"
@@ -224,7 +233,9 @@ def test_geometry_only_column():
         INSTALL spatial;
         LOAD spatial;
         CREATE TABLE data AS
-            SELECT CAST(geom as POINT_2D) as geom FROM ST_Read("{cities_gdal_path}");
+            -- Cast via plain GEOMETRY: DuckDB 1.5+ can't cast its
+            -- CRS-parameterized GEOMETRY directly to POINT_2D
+            SELECT CAST(geom::GEOMETRY as POINT_2D) as geom FROM ST_Read("{cities_gdal_path}");
         """
     con.execute(sql)
 


### PR DESCRIPTION
Written by Claude:

----

### Problem

DuckDB 1.5's spatial extension parameterizes the `GEOMETRY` type with a CRS (e.g. `GEOMETRY('EPSG:4326')`). Lonboard detects geometry columns in `from_duckdb` by exact string comparison against `"GEOMETRY"`, which no longer matches, so `viz()` and `Layer.from_duckdb` fail with `ValueError: No geometry column found` for any relation read via `ST_Read` under DuckDB ≥ 1.5. (Found while attempting a lockfile upgrade: 11 tests in `tests/test_duckdb.py` fail with duckdb 1.5.3.)

### Fix

Match geometry columns by the base type name with type parameters stripped, which behaves identically on DuckDB 1.4. Once detected, the existing `ST_AsWKB` conversion path works unchanged on both versions.

Tests are made version-agnostic:
- `GEOMETRY` type assertions accept the parameterized form.
- `ST_AsWKB` returns plain `BLOB` (not `WKB_BLOB`) in DuckDB 1.5, so the WKB tests cast its result with `::WKB_BLOB` to keep exercising lonboard's `WKB_BLOB` path.
- DuckDB 1.5 has no cast from CRS-parameterized `GEOMETRY` to `POINT_2D` (`ConversionException` at execution), so the `POINT_2D` tests cast through plain `GEOMETRY` first (a no-op on 1.4).

`uv.lock` is intentionally untouched; the dependency bump can land separately once this merges.

### Verification

- duckdb 1.4.4 (locked), full suite: `185 passed, 1 skipped`
- duckdb 1.5.3 (`uv run --with duckdb==1.5.3`), `tests/test_duckdb.py`: `14 passed, 1 skipped` (was `11 failed, 3 passed, 1 skipped` before the fix)

### Follow-up

DuckDB 1.5 exposes the CRS via the type parameter and attaches `geoarrow.wkb` extension metadata (with PROJJSON CRS) to its Arrow export; lonboard could propagate that CRS instead of warning that none exists. Kept out of scope here to stay minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)