### PR TITLE
fix: Support h3 4.5.0 

### DIFF
--- a/lonboard/layer/_h3.py
+++ b/lonboard/layer/_h3.py
@@ -7,6 +7,7 @@ import numpy as np
 
 import lonboard.traits as t
 from lonboard._geoarrow.ops import Bbox, WeightedCentroid
+from lonboard._h3._validate_h3_cell import get_resolution
 from lonboard._utils import auto_downcast as _auto_downcast
 from lonboard.layer._polygon import PolygonLayer
 
@@ -50,21 +51,29 @@ def default_h3_viewport(ca: ChunkedArray) -> tuple[Bbox, WeightedCentroid] | Non
         )
         return None
 
-    geo_dict = h3.cells_to_geo(sample_h3)
+    # h3 >= 4.5 raises H3ResMismatchError when `cells_to_geo` is passed cells of
+    # mixed resolutions, so group the sampled cells by resolution and call it
+    # once per resolution.
+    resolutions = get_resolution(sample_h3)
+    coord_list: list[tuple[float, float]] = []
+    for res in np.unique(resolutions):
+        geo_dict = h3.cells_to_geo(sample_h3[resolutions == res])
 
-    geom_type = geo_dict.get("type")
-    if geom_type == "Polygon":
-        polygons = [geo_dict["coordinates"]]
-    elif geom_type == "MultiPolygon":
-        polygons = geo_dict["coordinates"]
-    else:
-        # I think it should always be Polygon/MultiPolygon
+        geom_type = geo_dict.get("type")
+        if geom_type == "Polygon":
+            polygons = [geo_dict["coordinates"]]
+        elif geom_type == "MultiPolygon":
+            polygons = geo_dict["coordinates"]
+        else:
+            # I think it should always be Polygon/MultiPolygon
+            continue
+
+        coord_list.extend(pt for polygon in polygons for ring in polygon for pt in ring)
+
+    if not coord_list:
         return None
 
-    coords = np.array(
-        [pt for polygon in polygons for ring in polygon for pt in ring],
-        dtype=np.float64,
-    )
+    coords = np.array(coord_list, dtype=np.float64)
     centroid = coords.mean(axis=0)
 
     minx, miny = coords.min(axis=0)

--- a/tests/test_h3/test_h3_layer.py
+++ b/tests/test_h3/test_h3_layer.py
@@ -1,5 +1,7 @@
 # ruff: noqa: ERA001
 
+import math
+
 import numpy as np
 import pandas as pd
 import pyarrow as pa
@@ -42,6 +44,21 @@ def test_from_geopandas():
     layer = H3HexagonLayer.from_pandas(df, get_hexagon=hex_str_pa_arr)
     m = Map(layer)
     assert isinstance(m.layers[0], H3HexagonLayer)
+
+
+def test_mixed_resolution_default_viewport():
+    # VALID_INDICES contains one cell at each resolution 0-15. h3 >= 4.5 raises
+    # H3ResMismatchError from `cells_to_geo` when given mixed-resolution cells,
+    # so the default viewport must be computed per-resolution. Pin that a layer
+    # built from mixed-resolution cells gets a real default viewport.
+    df = pd.DataFrame({"h3": VALID_INDICES})
+    layer = H3HexagonLayer.from_pandas(df, get_hexagon=VALID_INDICES)
+
+    bbox = layer._bbox
+    assert all(math.isfinite(val) for val in bbox.to_tuple())
+    assert bbox.minx < bbox.maxx
+    assert bbox.miny < bbox.maxy
+    assert layer._weighted_centroid.num_items == len(VALID_INDICES)
 
 
 # We removed invalid index checking because of spurious validation errors with


### PR DESCRIPTION
Compute default H3 viewport per resolution for h3 4.5 compatibility

Written by Claude:
----

### Problem

h3 4.5.0's `cells_to_geo` (via `cells_to_h3shape`) raises `H3ResMismatchError` when passed cells of mixed resolutions. `default_h3_viewport` passes the full cell sample in a single call, so constructing an `H3HexagonLayer` from mixed-resolution cells crashes during default-viewport computation under h3 ≥ 4.5. (Found while attempting a lockfile upgrade; any user with mixed-resolution cells would hit this.)

### Fix

Group the sampled cells by resolution (using lonboard's existing vectorized `get_resolution` bit-mask helper, no extra h3 calls) and call `cells_to_geo` once per resolution — at most 16 calls — then derive the bbox/centroid from the combined boundary coordinates. Behavior is unchanged for single-resolution inputs and works under both h3 4.4 and 4.5. This preserves the boundary-based bbox semantics; a centroid-only approach would understate the bbox for coarse cells.

Adds `test_mixed_resolution_default_viewport`, which builds a layer from one cell at each resolution 0–15 and asserts a real finite viewport is computed. Verified red under h3 4.5.0 before the fix (`H3ResMismatchError`), green under both versions after.

`uv.lock` is intentionally untouched; the dependency bump can land separately once this merges.

### Verification

- h3 4.4.2 (locked), full suite: `186 passed, 1 skipped`
- h3 4.5.0 (`uv run --with h3==4.5.0`), `tests/test_h3/`: `34 passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
