### PR TITLE
fix: map.set_view_state and linked maps example

### DIFF
--- a/examples/linked-maps.ipynb
+++ b/examples/linked-maps.ipynb
@@ -70,7 +70,7 @@
     "import traitlets\n",
     "\n",
     "from lonboard import Map\n",
-    "from lonboard.basemap import CartoBasemap\n",
+    "from lonboard.basemap import CartoStyle, MaplibreBasemap\n",
     "from lonboard.view_state import MapViewState"
    ]
   },
@@ -96,7 +96,7 @@
     "## Create postitron map focused on the arch\n",
     "positron_map = Map(\n",
     "    layers=[],\n",
-    "    basemap_style=CartoBasemap.Positron,\n",
+    "    basemap=MaplibreBasemap(style=CartoStyle.Positron),\n",
     "    view_state={\n",
     "        \"longitude\": -90.1849,\n",
     "        \"latitude\": 38.6245,\n",
@@ -110,7 +110,7 @@
     "## Create postitron map focused on the lady liberty\n",
     "darkmatter_map = Map(\n",
     "    layers=[],\n",
-    "    basemap_style=CartoBasemap.DarkMatter,\n",
+    "    basemap=MaplibreBasemap(style=CartoStyle.DarkMatter),\n",
     "    view_state={\n",
     "        \"longitude\": -74.04454,\n",
     "        \"latitude\": 40.6892,\n",
@@ -144,7 +144,7 @@
    "source": [
     "def sync_positron_to_darkmatter(event: traitlets.utils.bunch.Bunch) -> None:\n",
     "    if isinstance(event.get(\"new\"), MapViewState):\n",
-    "        darkmatter_map.view_state = positron_map.view_state\n",
+    "        darkmatter_map.set_view_state(positron_map.view_state)\n",
     "\n",
     "\n",
     "positron_map.observe(sync_positron_to_darkmatter)\n",
@@ -152,7 +152,7 @@
     "\n",
     "def sync_darkmatter_to_positron(event: traitlets.utils.bunch.Bunch) -> None:\n",
     "    if isinstance(event.get(\"new\"), MapViewState):\n",
-    "        positron_map.view_state = darkmatter_map.view_state\n",
+    "        positron_map.set_view_state(darkmatter_map.view_state)\n",
     "\n",
     "\n",
     "darkmatter_map.observe(sync_darkmatter_to_positron)"
@@ -181,7 +181,7 @@
     ") -> None:\n",
     "    if isinstance(event.get(\"new\"), MapViewState):\n",
     "        for lonboard_map in other_maps:\n",
-    "            lonboard_map.view_state = event[\"new\"]\n",
+    "            lonboard_map.set_view_state(event[\"new\"])\n",
     "\n",
     "\n",
     "positron_map.observe(partial(link_maps, other_maps=[darkmatter_map]))\n",
@@ -212,7 +212,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.13.1"
   }
  },
  "nbformat": 4,

--- a/lonboard/_map.py
+++ b/lonboard/_map.py
@@ -576,36 +576,30 @@ class Map(BaseAnyWidget):
 
         """
         if view_state is not None:
-            self.view_state = view_state
-            return
+            longitude = view_state.longitude
+            latitude = view_state.latitude
+            zoom = view_state.zoom
+            pitch = view_state.pitch
+            bearing = view_state.bearing
 
-        current_view_state = self.view_state
+        if longitude is None:
+            longitude = self.view_state.longitude
+        if latitude is None:
+            latitude = self.view_state.latitude
+        if zoom is None:
+            zoom = self.view_state.zoom
+        if pitch is None:
+            pitch = self.view_state.pitch
+        if bearing is None:
+            bearing = self.view_state.bearing
 
-        changes = {}
-        if longitude is not None:
-            changes["longitude"] = longitude
-        if latitude is not None:
-            changes["latitude"] = latitude
-        if zoom is not None:
-            changes["zoom"] = zoom
-
-        # Only params allowed by globe view state
-        if isinstance(current_view_state, GlobeViewState):
-            self.view_state = replace(current_view_state, **changes)
-            return
-
-        # Add more params allowed by map view state
-        if pitch is not None:
-            changes["pitch"] = pitch
-        if bearing is not None:
-            changes["bearing"] = bearing
-
-        if isinstance(current_view_state, MapViewState):
-            self.view_state = replace(current_view_state, **changes)
-            return
-
-        raise TypeError(
-            "Can only set MapViewState or GlobeViewState parameters individually via set_view_state.\nFor other view state types, pass a complete view_state object.",
+        self.fly_to(
+            longitude=longitude,
+            latitude=latitude,
+            zoom=zoom,
+            duration=0,
+            pitch=pitch,
+            bearing=bearing,
         )
 
     def fly_to(  # noqa: PLR0913

--- a/lonboard/_map.py
+++ b/lonboard/_map.py
@@ -648,6 +648,12 @@ class Map(BaseAnyWidget):
         if not isinstance(zoom, (int, float, np.number)):
             raise TypeError(f"Expected zoom to be an int or float, got {type(zoom)}")
 
+        if not isinstance(pitch, (int, float, np.number)):
+            raise TypeError(f"Expected pitch to be an int or float, got {type(pitch)}")
+
+        if not isinstance(bearing, (int, float, np.number)):
+            raise TypeError(f"Expected bearing to be an int or float, got {type(bearing)}")
+
         data = {
             "type": "fly-to",
             "longitude": longitude,


### PR DESCRIPTION
This PR fixes the `set_view_state` function from the python side by calling `fly_to` with `duration=0`, and updates the linked maps example to make it functional again.  Admittedly, this is not the ideal solution, of fixing it on the JS side, but it does get the set_view_state function and linked maps example working.  I thought I'd push it up as a fix until someone with the necessary JS/TS/React skills to fix it properly has time. If you'd rather hold off for the ideal fix, I won't take it personally 😄. 

While I was in there I noticed that we weren't checking that the pitch and bearing inputs of `fly_to` were numeric, so I added that in there as well.

fixes #1062 #1024